### PR TITLE
Move the album art image to the embed

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -87,6 +87,7 @@ public partial class ShareMusicCommandModule
                 .WithTitle(streamingEntityItem.Title)
                 .WithDescription($"by {streamingEntityItem.ArtistName}")
                 .WithColor(Color.DarkBlue)
+                .WithImageUrl($"attachment://{streamingEntityItem.Title}.jpg")
                 .WithFooter("(Powered by Songlink/Odesli)");
 
             await Context.Channel.SendFileAsync(

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
@@ -78,6 +78,7 @@ public partial class ShareMusicCommandModule
             .WithTitle(streamingEntityItem.Title)
             .WithDescription($"by {streamingEntityItem.ArtistName}")
             .WithColor(Color.DarkBlue)
+            .WithImageUrl($"attachment://{streamingEntityItem.Title}.jpg")
             .WithFooter("(Powered by Songlink/Odesli)");
 
         await FollowupWithFileAsync(


### PR DESCRIPTION
This moves the album art into the embed, rather than have it appear outside of it.

Before:

![Without the image in the embed](https://github.com/Smalls1652/MuzakBot/assets/1042907/a0019d8b-e74a-47e9-b393-e314e8769cd9)

After:
![With the image in the embed](https://github.com/Smalls1652/MuzakBot/assets/1042907/d083e4a2-735d-49f0-9b5e-262c11ba321b)
