### PR TITLE
Renamed GetMusicEntityItemAlbumArtAsync to GetAlbumArtStreamAsync

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -79,7 +79,7 @@ public partial class ShareMusicCommandModule
             }
 
             StreamingEntityItem streamingEntityItem = musicEntityItem.EntitiesByUniqueId![platformEntityLink.EntityUniqueId!];
-            using var albumArtStream = await GetMusicEntityItemAlbumArtAsync(streamingEntityItem);
+            using var albumArtStream = await GetAlbumArtStreamAsync(streamingEntityItem);
 
             var linksComponentBuilder = GenerateMusicShareComponent(musicEntityItem);
 

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
@@ -70,7 +70,7 @@ public partial class ShareMusicCommandModule
         }
 
         StreamingEntityItem streamingEntityItem = musicEntityItem.EntitiesByUniqueId![platformEntityLink.EntityUniqueId!];
-        using var albumArtStream = await GetMusicEntityItemAlbumArtAsync(streamingEntityItem);
+        using var albumArtStream = await GetAlbumArtStreamAsync(streamingEntityItem);
 
         var linksComponentBuilder = GenerateMusicShareComponent(musicEntityItem);
 

--- a/src/App/Modules/ShareMusicCommandModule/helpers/GetAlbumArtStreamAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/helpers/GetAlbumArtStreamAsync.cs
@@ -4,7 +4,7 @@ namespace MuzakBot.App.Modules;
 
 public partial class ShareMusicCommandModule
 {
-    private async Task<Stream> GetMusicEntityItemAlbumArtAsync(StreamingEntityItem entityItem)
+    private async Task<Stream> GetAlbumArtStreamAsync(StreamingEntityItem entityItem)
     {
         var httpClient = _httpClientFactory.CreateClient("GenericClient");
 


### PR DESCRIPTION
Changing the name of the `GetMusicEntityItemAlbumArtAsync` method to `GetAlbumArtStreamAsync` for clarity in both:

* What it does
* What it returns