### PR TITLE
Move embed building to own method

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -83,12 +83,7 @@ public partial class ShareMusicCommandModule
 
             var linksComponentBuilder = GenerateMusicShareComponent(musicEntityItem);
 
-            var messageEmbed = new EmbedBuilder()
-                .WithTitle(streamingEntityItem.Title)
-                .WithDescription($"by {streamingEntityItem.ArtistName}")
-                .WithColor(Color.DarkBlue)
-                .WithImageUrl($"attachment://{streamingEntityItem.Title}.jpg")
-                .WithFooter("(Powered by Songlink/Odesli)");
+            var messageEmbed = GenerateEmbedBuilder(streamingEntityItem);
 
             await Context.Channel.SendFileAsync(
                 embed: messageEmbed.Build(),

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
@@ -70,21 +70,16 @@ public partial class ShareMusicCommandModule
         }
 
         StreamingEntityItem streamingEntityItem = musicEntityItem.EntitiesByUniqueId![platformEntityLink.EntityUniqueId!];
-        using var albumArtStream = await GetAlbumArtStreamAsync(streamingEntityItem);
+        await using var albumArtStream = await GetAlbumArtStreamAsync(streamingEntityItem);
 
         var linksComponentBuilder = GenerateMusicShareComponent(musicEntityItem);
 
-        var messageEmbed = new EmbedBuilder()
-            .WithTitle(streamingEntityItem.Title)
-            .WithDescription($"by {streamingEntityItem.ArtistName}")
-            .WithColor(Color.DarkBlue)
-            .WithImageUrl($"attachment://{streamingEntityItem.Title}.jpg")
-            .WithFooter("(Powered by Songlink/Odesli)");
+        var messageEmbed = GenerateEmbedBuilder(streamingEntityItem);
 
         await FollowupWithFileAsync(
             embed: messageEmbed.Build(),
             fileStream: albumArtStream,
-            fileName: $"{streamingEntityItem.Title}.jpg",
+            fileName: $"{streamingEntityItem.Id}.jpg",
             components: linksComponentBuilder.Build()
         );
 

--- a/src/App/Modules/ShareMusicCommandModule/helpers/GenerateEmbedBuilder.cs
+++ b/src/App/Modules/ShareMusicCommandModule/helpers/GenerateEmbedBuilder.cs
@@ -1,0 +1,17 @@
+using Discord;
+using MuzakBot.App.Models.Odesli;
+
+namespace MuzakBot.App.Modules;
+
+public partial class ShareMusicCommandModule
+{
+    private EmbedBuilder GenerateEmbedBuilder(StreamingEntityItem streamingEntityItem)
+    {
+        return new EmbedBuilder()
+            .WithTitle(streamingEntityItem.Title)
+            .WithDescription($"by {streamingEntityItem.ArtistName}")
+            .WithColor(Color.DarkBlue)
+            .WithImageUrl($"attachment://{streamingEntityItem.Id}.jpg")
+            .WithFooter("(Powered by Songlink/Odesli)");
+    }
+}


### PR DESCRIPTION
Refactoring embed building to it's own method. I try to stay away from doing things like this, but it's one of those things that's being done inside other methods. For keeping the output consistent across all of them, this should make it easier to do.