### PR TITLE
Remove duplicate song/album names in autocomplete options

### DIFF
--- a/src/App/Handlers/ArtistAlbumSearchAutoCompleteHandler.cs
+++ b/src/App/Handlers/ArtistAlbumSearchAutoCompleteHandler.cs
@@ -63,8 +63,21 @@ public class ArtistAlbumSearchAutoCompleteHandler : AutocompleteHandler
             return AutocompletionResult.FromSuccess(results.AsEnumerable());
         }
 
+        MusicBrainzReleaseItem[]? distinctAlbumItems = albumSearchResult.GetDistinct();
 
-        foreach (MusicBrainzReleaseItem releaseItem in albumSearchResult.Releases)
+        if (distinctAlbumItems is null || distinctAlbumItems.Length == 0)
+        {
+            results.Add(
+                item: new(
+                    name: "No results found",
+                    value: ""
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        foreach (MusicBrainzReleaseItem releaseItem in distinctAlbumItems)
         {
             results.Add(
                 item: new(

--- a/src/App/Handlers/ArtistSongSearchAutoCompleteHandler.cs
+++ b/src/App/Handlers/ArtistSongSearchAutoCompleteHandler.cs
@@ -63,8 +63,21 @@ public class ArtistSongSearchAutoCompleteHandler : AutocompleteHandler
             return AutocompletionResult.FromSuccess(results.AsEnumerable());
         }
 
+        MusicBrainzRecordingItem[]? distinctSongItems = songSearchResult.GetDistinct();
 
-        foreach (MusicBrainzRecordingItem songItem in songSearchResult.Recordings)
+        if (distinctSongItems is null || distinctSongItems.Length == 0)
+        {
+            results.Add(
+                item: new(
+                    name: "No results found",
+                    value: ""
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        foreach (MusicBrainzRecordingItem songItem in distinctSongItems)
         {
             results.Add(
                 item: new(

--- a/src/App/Models/MusicBrainz/MusicBrainzRecordingSearchResults.cs
+++ b/src/App/Models/MusicBrainz/MusicBrainzRecordingSearchResults.cs
@@ -15,4 +15,9 @@ public class MusicBrainzRecordingSearchResult
 
     [JsonPropertyName("recordings")]
     public MusicBrainzRecordingItem[]? Recordings { get; set; }
+
+    public MusicBrainzRecordingItem[]? GetDistinct()
+    {
+        return Recordings?.DistinctBy(item => item.Title).ToArray();
+    }
 }

--- a/src/App/Models/MusicBrainz/MusicBrainzReleaseSearchResult.cs
+++ b/src/App/Models/MusicBrainz/MusicBrainzReleaseSearchResult.cs
@@ -15,4 +15,9 @@ public class MusicBrainzReleaseSearchResult
 
     [JsonPropertyName("releases")]
     public MusicBrainzReleaseItem[]? Releases { get; set; }
+
+    public MusicBrainzReleaseItem[]? GetDistinct()
+    {
+        return Releases?.DistinctBy(item => item.Title).ToArray();
+    }
 }


### PR DESCRIPTION
This removes duplicate song and album names from the autocomplete options list. It can be confusing when multiple of the same song show up in the list, so this is to help alleviate that.