### PR TITLE
Fix "Get music share links" embed

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -111,7 +111,7 @@ public partial class ShareMusicCommandModule
                 await Context.Channel.SendFileAsync(
                     embed: messageEmbed.Build(),
                     stream: albumArtStream,
-                    filename: $"{streamingEntityItem.Title}.jpg",
+                    filename: $"{streamingEntityItem.Id}.jpg",
                     components: linksComponentBuilder.Build(),
                     messageReference: new(message.Id),
                     allowedMentions: AllowedMentions.None


### PR DESCRIPTION
# Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

# Description

This PR fixes an issue with the **"Get music share links"** message command's embed not including the album art inside of it properly. This made it inconsistent from the embed in slash commands.

The issue was caused by a mismatch between the filename the embed was expecting and what the attached file's name to the message was.

## Related issues

None
