### PR TITLE
Fix null typing for iTunes SongItem

### DIFF
--- a/src/App/Models/ITunes/SongItem.cs
+++ b/src/App/Models/ITunes/SongItem.cs
@@ -5,10 +5,10 @@ namespace MuzakBot.App.Models.Itunes;
 public class SongItem : ISongItem
 {
     [JsonPropertyName("wrapperType")]
-    public string WrapperType { get; set; }
+    public string? WrapperType { get; set; }
 
     [JsonPropertyName("kind")]
-    public string Kind { get; set; }
+    public string? Kind { get; set; }
 
     [JsonPropertyName("artistId")]
     public long ArtistId { get; set; }
@@ -20,40 +20,40 @@ public class SongItem : ISongItem
     public long TrackId { get; set; }
 
     [JsonPropertyName("artistName")]
-    public string ArtistName { get; set; }
+    public string? ArtistName { get; set; }
 
     [JsonPropertyName("collectionName")]
-    public string CollectionName { get; set; }
+    public string? CollectionName { get; set; }
 
     [JsonPropertyName("trackName")]
-    public string TrackName { get; set; }
+    public string? TrackName { get; set; }
 
     [JsonPropertyName("collectionCensoredName")]
-    public string CollectionCensoredName { get; set; }
+    public string? CollectionCensoredName { get; set; }
 
     [JsonPropertyName("trackCensoredName")]
-    public string TrackCensoredName { get; set; }
+    public string? TrackCensoredName { get; set; }
 
     [JsonPropertyName("artistViewUrl")]
-    public string ArtistViewUrl { get; set; }
+    public string? ArtistViewUrl { get; set; }
 
     [JsonPropertyName("collectionViewUrl")]
-    public string CollectionViewUrl { get; set; }
+    public string? CollectionViewUrl { get; set; }
 
     [JsonPropertyName("trackViewUrl")]
-    public string TrackViewUrl { get; set; }
+    public string? TrackViewUrl { get; set; }
 
     [JsonPropertyName("previewUrl")]
-    public string PreviewUrl { get; set; }
+    public string? PreviewUrl { get; set; }
 
     [JsonPropertyName("artworkUrl30")]
-    public string ArtworkUrl30 { get; set; }
+    public string? ArtworkUrl30 { get; set; }
 
     [JsonPropertyName("artworkUrl60")]
-    public string ArtworkUrl60 { get; set; }
+    public string? ArtworkUrl60 { get; set; }
 
     [JsonPropertyName("artworkUrl100")]
-    public string ArtworkUrl100 { get; set; }
+    public string? ArtworkUrl100 { get; set; }
 
     [JsonPropertyName("collectionPrice")]
     public double CollectionPrice { get; set; }
@@ -65,10 +65,10 @@ public class SongItem : ISongItem
     public DateTimeOffset ReleaseDate { get; set; }
 
     [JsonPropertyName("collectionExplicitness")]
-    public string CollectionExplicitness { get; set; }
+    public string? CollectionExplicitness { get; set; }
 
     [JsonPropertyName("trackExplicitness")]
-    public string TrackExplicitness { get; set; }
+    public string? TrackExplicitness { get; set; }
 
     [JsonPropertyName("discCount")]
     public int DiscCount { get; set; }
@@ -86,13 +86,13 @@ public class SongItem : ISongItem
     public long TrackTimeMillis { get; set; }
 
     [JsonPropertyName("country")]
-    public string Country { get; set; }
+    public string? Country { get; set; }
 
     [JsonPropertyName("currency")]
-    public string Currency { get; set; }
+    public string? Currency { get; set; }
 
     [JsonPropertyName("primaryGenreName")]
-    public string PrimaryGenreName { get; set; }
+    public string? PrimaryGenreName { get; set; }
 
     [JsonPropertyName("isStreamable")]
     public bool IsStreamable { get; set; }

--- a/src/App/Models/ITunes/interfaces/ISongItem.cs
+++ b/src/App/Models/ITunes/interfaces/ISongItem.cs
@@ -2,35 +2,35 @@ namespace MuzakBot.App.Models.Itunes;
 
 public interface ISongItem
 {
-    string WrapperType { get; set; }
-    string Kind { get; set; }
+    string? WrapperType { get; set; }
+    string? Kind { get; set; }
     long ArtistId { get; set; }
     long CollectionId { get; set; }
     long TrackId { get; set; }
-    string ArtistName { get; set; }
-    string CollectionName { get; set; }
-    string TrackName { get; set; }
-    string CollectionCensoredName { get; set; }
-    string TrackCensoredName { get; set; }
-    string ArtistViewUrl { get; set; }
-    string CollectionViewUrl { get; set; }
-    string TrackViewUrl { get; set; }
-    string PreviewUrl { get; set; }
-    string ArtworkUrl30 { get; set; }
-    string ArtworkUrl60 { get; set; }
-    string ArtworkUrl100 { get; set; }
+    string? ArtistName { get; set; }
+    string? CollectionName { get; set; }
+    string? TrackName { get; set; }
+    string? CollectionCensoredName { get; set; }
+    string? TrackCensoredName { get; set; }
+    string? ArtistViewUrl { get; set; }
+    string? CollectionViewUrl { get; set; }
+    string? TrackViewUrl { get; set; }
+    string? PreviewUrl { get; set; }
+    string? ArtworkUrl30 { get; set; }
+    string? ArtworkUrl60 { get; set; }
+    string? ArtworkUrl100 { get; set; }
     double CollectionPrice { get; set; }
     double TrackPrice { get; set; }
     DateTimeOffset ReleaseDate { get; set; }
-    string CollectionExplicitness { get; set; }
-    string TrackExplicitness { get; set; }
+    string? CollectionExplicitness { get; set; }
+    string? TrackExplicitness { get; set; }
     int DiscCount { get; set; }
     int DiscNumber { get; set; }
     int TrackCount { get; set; }
     int TrackNumber { get; set; }
     long TrackTimeMillis { get; set; }
-    string Country { get; set; }
-    string Currency { get; set; }
-    string PrimaryGenreName { get; set; }
+    string? Country { get; set; }
+    string? Currency { get; set; }
+    string? PrimaryGenreName { get; set; }
     bool IsStreamable { get; set; }
 }

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleFindSongAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleFindSongAsync.cs
@@ -43,7 +43,7 @@ public partial class ShareMusicCommandModule
                 { "channel_Name", Context.Channel.Name }
             }
         );
-        
+
         try
         {
             await DeferAsync(
@@ -115,6 +115,11 @@ public partial class ShareMusicCommandModule
             MusicEntityItem? musicEntityItem = null;
             try
             {
+                if (songItem.TrackViewUrl is null)
+                {
+                    throw new Exception("No song item or track view url found.");
+                }
+
                 musicEntityItem = await _odesliService.GetShareLinksAsync(songItem.TrackViewUrl);
 
                 if (musicEntityItem is null)


### PR DESCRIPTION
## Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

## Description

This PR fixes the null typing for the string properties for the `SongItem` class.

### Related issues

- Fixes #29
