### PR TITLE
Update DiscordService lifecycle

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/ShareMusicCommandModule.cs
+++ b/src/App/Modules/ShareMusicCommandModule/ShareMusicCommandModule.cs
@@ -15,7 +15,6 @@ public partial class ShareMusicCommandModule : InteractionModuleBase, IDisposabl
 {
     private bool _isDisposed;
     private readonly ActivitySource _activitySource = new("MuzakBot.App.Modules.ShareMusicCommandModule");
-    private readonly IDiscordService _discordService;
     private readonly IOdesliService _odesliService;
     private readonly IItunesApiService _itunesApiService;
     private readonly IMusicBrainzService _musicBrainzService;
@@ -23,9 +22,8 @@ public partial class ShareMusicCommandModule : InteractionModuleBase, IDisposabl
     private readonly ILogger<ShareMusicCommandModule> _logger;
     private readonly CommandMetrics _commandMetrics;
 
-    public ShareMusicCommandModule(IDiscordService discordService, IOdesliService odesliService, IItunesApiService itunesApiService, IMusicBrainzService musicBrainzService, IHttpClientFactory httpClientFactory, ILogger<ShareMusicCommandModule> logger, CommandMetrics commandMetrics)
+    public ShareMusicCommandModule(IOdesliService odesliService, IItunesApiService itunesApiService, IMusicBrainzService musicBrainzService, IHttpClientFactory httpClientFactory, ILogger<ShareMusicCommandModule> logger, CommandMetrics commandMetrics)
     {
-        _discordService = discordService;
         _odesliService = odesliService;
         _itunesApiService = itunesApiService;
         _musicBrainzService = musicBrainzService;

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -172,14 +172,12 @@ builder.Services.AddSingleton<DiscordSocketClient>(
     implementationInstance: new(discordSocketConfig)
 );
 
-builder.Services.AddSingleton<IDiscordService, DiscordService>();
+builder.Services.AddHostedService<DiscordService>();
+
 builder.Services.AddSingleton<IOdesliService, OdesliService>();
 builder.Services.AddSingleton<IItunesApiService, ItunesApiService>();
 builder.Services.AddSingleton<IMusicBrainzService, MusicBrainzService>();
 
 using var host = builder.Build();
-
-var discordService = host.Services.GetRequiredService<IDiscordService>();
-await discordService.ConnectAsync();
 
 await host.RunAsync();

--- a/src/App/Services/DiscordService/interfaces/IDiscordService.cs
+++ b/src/App/Services/DiscordService/interfaces/IDiscordService.cs
@@ -5,7 +5,7 @@ namespace MuzakBot.App.Services;
 /// <summary>
 /// Interface for the Discord service.
 /// </summary>
-public interface IDiscordService
+public interface IDiscordService : IAsyncDisposable
 {
     /// <summary>
     /// Connects the bot to Discord.


### PR DESCRIPTION
## Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

## Description

This PR updates **how** `DiscordService` starts and stops.

Previously, the service was added as a "singleton" during the startup process and was "pulled out" during startup to initiate the connection to Discord. It wasn't an ideal solution for handling startup, but... It worked™.

With this change, `DiscordService` inherits the `IHostedService` interface, which means it now implements the `StartAsync()` and `StopAsync()` methods. This comes with two benefits:

1. The service will startup automatically with the .NET generic host.
2. The service will now attempt to shutdown gracefully when a shutdown signal is received, which will allow the bot to logout of Discord properly.

### Related issues

None
