### PR TITLE
Tweak telemetry error statuses

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleFindAlbumAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleFindAlbumAsync.cs
@@ -64,6 +64,8 @@ public partial class ShareMusicCommandModule
                     ephemeral: false
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 
@@ -82,6 +84,8 @@ public partial class ShareMusicCommandModule
                     ephemeral: false
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 
@@ -92,6 +96,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build(),
                     ephemeral: false
                 );
+
+                activity?.SetStatus(ActivityStatusCode.Error);
 
                 return;
             }
@@ -105,6 +111,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build(),
                     ephemeral: false
                 );
+
+                activity?.SetStatus(ActivityStatusCode.Error);
 
                 return;
             }
@@ -132,6 +140,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build()
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 
@@ -155,6 +165,8 @@ public partial class ShareMusicCommandModule
                         embed: GenerateErrorEmbed("I was unable to get the necessary information from Odesli. 😥").Build(),
                         components: GenerateRemoveComponent().Build()
                     );
+
+                    activity?.SetStatus(ActivityStatusCode.Error);
 
                     return;
                 }

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleFindSongAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleFindSongAsync.cs
@@ -64,6 +64,8 @@ public partial class ShareMusicCommandModule
                     ephemeral: false
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 
@@ -82,6 +84,8 @@ public partial class ShareMusicCommandModule
                     ephemeral: false
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 
@@ -92,6 +96,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build(),
                     ephemeral: false
                 );
+
+                activity?.SetStatus(ActivityStatusCode.Error);
 
                 return;
             }
@@ -105,6 +111,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build(),
                     ephemeral: false
                 );
+
+                activity?.SetStatus(ActivityStatusCode.Error);
 
                 return;
             }
@@ -135,6 +143,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build()
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 
@@ -158,6 +168,8 @@ public partial class ShareMusicCommandModule
                         embed: GenerateErrorEmbed("I was unable to get the necessary information from Odesli. 😥").Build(),
                         components: GenerateRemoveComponent().Build()
                     );
+
+                    activity?.SetStatus(ActivityStatusCode.Error);
 
                     return;
                 }

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -53,6 +53,8 @@ public partial class ShareMusicCommandModule
                     ephemeral: true
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 return;
             }
 

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
@@ -64,6 +64,8 @@ public partial class ShareMusicCommandModule
                     components: GenerateRemoveComponent().Build()
                 );
 
+                activity?.SetStatus(ActivityStatusCode.Error);
+
                 throw;
             }
 
@@ -88,6 +90,8 @@ public partial class ShareMusicCommandModule
                         components: GenerateRemoveComponent().Build()
                     );
 
+                    activity?.SetStatus(ActivityStatusCode.Error);
+
                     throw;
                 }
             }
@@ -105,6 +109,8 @@ public partial class ShareMusicCommandModule
                     embed: GenerateErrorEmbed("I ran into an issue while retrieving the album artwork. 😥").Build(),
                     components: GenerateRemoveComponent().Build()
                 );
+
+                activity?.SetStatus(ActivityStatusCode.Error);
 
                 throw;
             }


### PR DESCRIPTION
## Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

## Description

This PR fixes an issue with telemetry traces, for commands that fail, still reporting that it was successful. When an error is returned back to the client, the trace activity's status for the execution is now manually set to "error".

### Related issues

None
