### PR TITLE
Fix iTunes fallback causing response to hang

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleFindAlbumAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleFindAlbumAsync.cs
@@ -152,7 +152,14 @@ public partial class ShareMusicCommandModule
             }
             catch
             {
-                var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null).Value.ApiProvider;
+                /*
+                    Temporary fix:
+                    
+                    Amazon is being excluded from the fallback for the time being,
+                    because the "apiProvider" value doesn't cleanly match it's platform
+                    entity link key.
+                */
+                var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null && entity.Value.ApiProvider != "amazon").Value.ApiProvider;
 
                 if (!string.IsNullOrEmpty(streamingEntityWithThumbnailUrl))
                 {

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleFindSongAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleFindSongAsync.cs
@@ -155,7 +155,14 @@ public partial class ShareMusicCommandModule
             }
             catch
             {
-                var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null).Value.ApiProvider;
+                /*
+                    Temporary fix:
+                    
+                    Amazon is being excluded from the fallback for the time being,
+                    because the "apiProvider" value doesn't cleanly match it's platform
+                    entity link key.
+                */
+                var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null && entity.Value.ApiProvider != "amazon").Value.ApiProvider;
 
                 if (!string.IsNullOrEmpty(streamingEntityWithThumbnailUrl))
                 {

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -35,7 +35,7 @@ public partial class ShareMusicCommandModule
                 { "channel_Name", Context.Channel.Name }
             }
         );
-        
+
         try
         {
             Regex linkRegex = new(@"(?'musicLink'(?>https|http):\/\/(?>[A-Za-z0-9\.]+)(?>\/\S*[^\.\s]|))(?> |)", RegexOptions.Multiline);
@@ -89,7 +89,14 @@ public partial class ShareMusicCommandModule
                 }
                 catch
                 {
-                    var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null).Value.ApiProvider;
+                    /*
+                    Temporary fix:
+                    
+                    Amazon is being excluded from the fallback for the time being,
+                    because the "apiProvider" value doesn't cleanly match it's platform
+                    entity link key.
+                */
+                    var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null && entity.Value.ApiProvider != "amazon").Value.ApiProvider;
 
                     if (!string.IsNullOrEmpty(streamingEntityWithThumbnailUrl))
                     {

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareAsync.cs
@@ -76,7 +76,14 @@ public partial class ShareMusicCommandModule
             }
             catch (Exception ex)
             {
-                var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null).Value.ApiProvider;
+                /*
+                    Temporary fix:
+                    
+                    Amazon is being excluded from the fallback for the time being,
+                    because the "apiProvider" value doesn't cleanly match it's platform
+                    entity link key.
+                */
+                var streamingEntityWithThumbnailUrl = musicEntityItem.EntitiesByUniqueId!.FirstOrDefault(entity => entity.Value.ThumbnailUrl is not null && entity.Value.ApiProvider != "amazon").Value.ApiProvider;
 
                 if (!string.IsNullOrEmpty(streamingEntityWithThumbnailUrl))
                 {


### PR DESCRIPTION
## Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

## Description

This is a quick fix for when iTunes wasn't found in the Odesli response and Amazon is selected as the fallback. I can't cleanly filter Amazon easily like I can for the other platforms, so I'm excluding it from being selected for the time being.

### Related issues

None
