### PR TITLE
Remove activity trace during DiscordService startup

### DIFF
--- a/src/App/Services/DiscordService/DiscordService.cs
+++ b/src/App/Services/DiscordService/DiscordService.cs
@@ -36,11 +36,6 @@ public class DiscordService : IDiscordService, IHostedService
     /// <inheritdoc cref="IDiscordService.ConnectAsync"/>
     public async Task ConnectAsync()
     {
-        var activity = _activitySource.StartActivity(
-            name: "ConnectAsync",
-            kind: ActivityKind.Internal
-        );
-
         // Log into Discord
         _logger.LogInformation("Connecting to Discord...");
 
@@ -73,8 +68,6 @@ public class DiscordService : IDiscordService, IHostedService
 
         // Add ready handler
         _discordSocketClient.Ready += OnClientReadyAsync;
-
-        activity?.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

## Description

This PR removes the trace events when the `ConnectAsync()` method is invoked for `DiscordService`. It's currently polluting the telemetry by unintentionally correlating to all Discord interaction requests.

I might re-add this later on.

### Related issues

None
