### PR TITLE
Add telemetry to music share refreshing

### DIFF
--- a/src/App/Extensions/ShareMusicCommandModuleActivityExtensions.cs
+++ b/src/App/Extensions/ShareMusicCommandModuleActivityExtensions.cs
@@ -112,6 +112,13 @@ internal static class ShareMusicCommandModuleActivityExtensions
         );
     }
 
+    /// <summary>
+    /// Starts an activity for handling the asynchronous music share refresh.
+    /// </summary>
+    /// <param name="activitySource">The activity source.</param>
+    /// <param name="url">The input URL.</param>
+    /// <param name="context">The interaction context.</param>
+    /// <returns>The started activity.</returns>
     public static Activity? StartHandleMusicShareRefreshAsyncActivity(this ActivitySource activitySource, string url, IInteractionContext context)
     {
         return activitySource.StartActivity(

--- a/src/App/Extensions/ShareMusicCommandModuleActivityExtensions.cs
+++ b/src/App/Extensions/ShareMusicCommandModuleActivityExtensions.cs
@@ -111,4 +111,23 @@ internal static class ShareMusicCommandModuleActivityExtensions
             }
         );
     }
+
+    public static Activity? StartHandleMusicShareRefreshAsyncActivity(this ActivitySource activitySource, string url, IInteractionContext context)
+    {
+        return activitySource.StartActivity(
+            name: "HandleMusicShareRefreshAsync",
+            kind: ActivityKind.Server,
+            tags: new ActivityTagsCollection
+            {
+                { "command_Type", "ComponentInteraction"},
+                { "command_Name", "Refresh music share links" },
+                { "url", url },
+                { "interaction_Id", context.Interaction.Id },
+                { "guild_Id", context.Guild.Id },
+                { "guild_Name", context.Guild.Name },
+                { "channel_Id", context.Channel.Id },
+                { "channel_Name", context.Channel.Name }
+            }
+        );
+    }
 }

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareRefreshAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleMusicShareRefreshAsync.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.Interactions;
+using MuzakBot.App.Extensions;
 using MuzakBot.App.Models.Odesli;
 using MuzakBot.App.Services;
 using Microsoft.Extensions.Logging;
@@ -20,6 +21,8 @@ public partial class ShareMusicCommandModule
     [ComponentInteraction(customId: "refresh-musiclinks-btn-*")]
     private async Task HandleMusicShareRefreshAsync(string url)
     {
+        using var activity = _activitySource.StartHandleMusicShareRefreshAsyncActivity(url, Context);
+        
         await Context.Interaction.DeferAsync(
             ephemeral: false
         );
@@ -27,7 +30,7 @@ public partial class ShareMusicCommandModule
         _logger.LogInformation("Refreshing music share links for {url}", url);
 
         // Get the music entity item from Odesli.
-        MusicEntityItem? musicEntityItem = await _odesliService.GetShareLinksAsync(url);
+        MusicEntityItem? musicEntityItem = await _odesliService.GetShareLinksAsync(url, activity?.Id);
 
         // Generate the music share components.
         ComponentBuilder linksComponentBuilder = GenerateMusicShareComponent(musicEntityItem!);


### PR DESCRIPTION
## Description

This PR adds telemetry when a refresh is triggered on a music share component.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

None
