### PR TITLE
Fix lyrics analyzer rate limit

### DIFF
--- a/src/App/Extensions/CosmosDbServiceActivityExtensions.cs
+++ b/src/App/Extensions/CosmosDbServiceActivityExtensions.cs
@@ -86,7 +86,7 @@ public static class CosmosDbServiceActivityExtensions
     /// <param name="activitySource">The <see cref="ActivitySource"/>.</param>
     /// <param name="userId">The ID of the user.</param>
     /// <returns>The started <see cref="Activity"/>.</returns>
-    public static Activity? StartDbGetLyricsAnalyzerUserRateLimitActivity(this ActivitySource activitySource, ulong userId) => StartDbGetLyricsAnalyzerUserRateLimitActivity(activitySource, userId, null);
+    public static Activity? StartDbGetLyricsAnalyzerUserRateLimitActivity(this ActivitySource activitySource, string userId) => StartDbGetLyricsAnalyzerUserRateLimitActivity(activitySource, userId, null);
 
     /// <summary>
     /// Starts an activity for getting a lyrics analyzer rate limit for a user from the database.
@@ -95,14 +95,14 @@ public static class CosmosDbServiceActivityExtensions
     /// <param name="userId">The ID of the user.</param>
     /// <param name="parentActivityId">The parent activity ID.</param>
     /// <returns>The started <see cref="Activity"/>.</returns>
-    public static Activity? StartDbGetLyricsAnalyzerUserRateLimitActivity(this ActivitySource activitySource, ulong userId, string? parentActivityId)
+    public static Activity? StartDbGetLyricsAnalyzerUserRateLimitActivity(this ActivitySource activitySource, string userId, string? parentActivityId)
     {
         return activitySource.StartActivity(
             name: "Database:GetLyricsAnalyzerUserRateLimitAsync",
             kind: ActivityKind.Internal,
             tags: new ActivityTagsCollection
             {
-                { "userId", userId.ToString() }
+                { "userId", userId }
             },
             parentId: parentActivityId
         );

--- a/src/App/Logging/CosmosDb/CosmosDbServiceLogging.cs
+++ b/src/App/Logging/CosmosDb/CosmosDbServiceLogging.cs
@@ -8,6 +8,31 @@ namespace MuzakBot.App.Logging.CosmosDb;
 internal static partial class CosmosDbServiceLogging
 {
     /// <summary>
+    /// Logs the initialization of the database and ensures that it exists.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger"/> instance.</param>
+    /// <param name="databaseName">The name of the database.</param>
+    [LoggerMessage(
+        EventName = "CosmosDbService.Initialize.EnsureDbExists",
+        Level = LogLevel.Information,
+        Message = "Ensuring that the database, '{databaseName}', exists."
+    )]
+    public static partial void LogInitializeEnsureDbExists(this ILogger logger, string databaseName);
+
+    /// <summary>
+    /// Logs the initialization of a container and ensures that it exists.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger"/> instance.</param>
+    /// <param name="containerName">The name of the container.</param>
+    /// <param name="databaseName">The name of the database.</param>
+    [LoggerMessage(
+        EventName = "CosmosDbService.Initialize.EnsureContainerExists",
+        Level = LogLevel.Information,
+        Message = "Ensuring that the container, '{containerName}', exists in '{databaseName}'."
+    )]
+    public static partial void LogInitializeEnsureContainerExists(this ILogger logger, string containerName, string databaseName);
+
+    /// <summary>
     /// Logs the start of an add or update operation to the database.
     /// </summary>
     /// <param name="logger">The <see cref="ILogger"/> instance.</param>

--- a/src/App/Models/Database/LyricsAnalyzer/LyricsAnalyzerUserRateLimit.cs
+++ b/src/App/Models/Database/LyricsAnalyzer/LyricsAnalyzerUserRateLimit.cs
@@ -16,7 +16,7 @@ public class LyricsAnalyzerUserRateLimit : DatabaseItem, ILyricsAnalyzerUserRate
     /// Initializes a new instance of the <see cref="LyricsAnalyzerUserRateLimit"/> class.
     /// </summary>
     /// <param name="userId">The user's ID.</param>
-    public LyricsAnalyzerUserRateLimit(ulong userId): this(userId, 0, DateTimeOffset.UtcNow)
+    public LyricsAnalyzerUserRateLimit(string userId): this(userId, 0, DateTimeOffset.UtcNow)
     {}
 
     /// <summary>
@@ -24,7 +24,7 @@ public class LyricsAnalyzerUserRateLimit : DatabaseItem, ILyricsAnalyzerUserRate
     /// </summary>
     /// <param name="userId">The user's ID.</param>
     /// <param name="currentRequestCount">The current request count.</param>
-    public LyricsAnalyzerUserRateLimit(ulong userId, int currentRequestCount): this(userId, currentRequestCount, DateTimeOffset.UtcNow)
+    public LyricsAnalyzerUserRateLimit(string userId, int currentRequestCount): this(userId, currentRequestCount, DateTimeOffset.UtcNow)
     {}
 
     /// <summary>
@@ -33,7 +33,7 @@ public class LyricsAnalyzerUserRateLimit : DatabaseItem, ILyricsAnalyzerUserRate
     /// <param name="userId">The user's ID.</param>
     /// <param name="currentRequestCount">The current request count.</param>
     /// <param name="lastRequestTime">The last request time.</param>
-    public LyricsAnalyzerUserRateLimit(ulong userId, int currentRequestCount, DateTimeOffset lastRequestTime)
+    public LyricsAnalyzerUserRateLimit(string userId, int currentRequestCount, DateTimeOffset lastRequestTime)
     {
         Id = Guid.NewGuid().ToString();
         PartitionKey = "user-item";
@@ -47,7 +47,7 @@ public class LyricsAnalyzerUserRateLimit : DatabaseItem, ILyricsAnalyzerUserRate
     /// The user's ID.
     /// </summary>
     [JsonPropertyName("userId")]
-    public ulong UserId { get; set; }
+    public string UserId { get; set; } = null!;
 
     /// <summary>
     /// The current request count.

--- a/src/App/Models/Database/LyricsAnalyzer/interface/ILyricsAnalyzerUserRateLimit.cs
+++ b/src/App/Models/Database/LyricsAnalyzer/interface/ILyricsAnalyzerUserRateLimit.cs
@@ -4,7 +4,7 @@ public interface ILyricsAnalyzerUserRateLimit
 {
     string Id { get; set; }
     string PartitionKey { get; set; }
-    ulong UserId { get; set; }
+    string UserId { get; set; }
     int CurrentRequestCount { get; set; }
     DateTimeOffset LastRequestTime { get; set; }
 

--- a/src/App/Modules/LyricsAnalyzerCommandModule/Commands/HandleLyricsAnalyzerAsync.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Commands/HandleLyricsAnalyzerAsync.cs
@@ -99,7 +99,7 @@ public partial class LyricsAnalyzerCommandModule
         if (lyricsAnalyzerConfig.RateLimitEnabled)
         {
             _logger.LogInformation("Getting current rate limit for user '{UserId}' from database.", Context.User.Id);
-            lyricsAnalyzerUserRateLimit = await _cosmosDbService.GetLyricsAnalyzerUserRateLimitAsync(Context.User.Id, activity?.Id);
+            lyricsAnalyzerUserRateLimit = await _cosmosDbService.GetLyricsAnalyzerUserRateLimitAsync(Context.User.Id.ToString(), activity?.Id);
 
             _logger.LogInformation("Current rate limit for user '{UserId}' is {CurrentRequestCount}/{MaxRequests}.", Context.User.Id, lyricsAnalyzerUserRateLimit.CurrentRequestCount, lyricsAnalyzerConfig.RateLimitMaxRequests);
 

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -82,4 +82,8 @@ builder.Services.AddDiscordService(options =>
 
 using var host = builder.Build();
 
+// Initialize the database and containers for the Cosmos DB service
+// before running the host.
+await host.Services.GetRequiredService<ICosmosDbService>().InitializeDatabaseAsync();
+
 await host.RunAsync();

--- a/src/App/Services/CosmosDbService/CosmosDbService.cs
+++ b/src/App/Services/CosmosDbService/CosmosDbService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MuzakBot.App.Logging.CosmosDb;
 
 namespace MuzakBot.App.Services;
 
@@ -26,6 +27,44 @@ public partial class CosmosDbService : ICosmosDbService
         _logger = logger;
         _options = options.Value;
         _cosmosDbClient = new CosmosClient(_options.ConnectionString);
+    }
+
+    /// <summary>
+    /// Initializes the database and containers for MuzakBot.
+    /// </summary>
+    /// <returns></returns>
+    public async Task InitializeDatabaseAsync()
+    {
+        // Initialize the database and containers for 'lyrics-analyzer',
+        // if they don't exist.
+        _logger.LogInitializeEnsureDbExists("lyrics-analyzer");
+        Database lyricsAnalyzerDb = await _cosmosDbClient.CreateDatabaseIfNotExistsAsync(
+            id: "lyrics-analyzer"
+        );
+
+        _logger.LogInitializeEnsureContainerExists("song-lyrics", "lyrics-analyzer");
+        await lyricsAnalyzerDb.CreateContainerIfNotExistsAsync(
+            id: "song-lyrics",
+            partitionKeyPath: "/partitionKey"
+        );
+
+        _logger.LogInitializeEnsureContainerExists("command-configs", "lyrics-analyzer");
+        await lyricsAnalyzerDb.CreateContainerIfNotExistsAsync(
+            id: "command-configs",
+            partitionKeyPath: "/partitionKey"
+        );
+
+        _logger.LogInitializeEnsureContainerExists("prompt-styles", "lyrics-analyzer");
+        await lyricsAnalyzerDb.CreateContainerIfNotExistsAsync(
+            id: "prompt-styles",
+            partitionKeyPath: "/partitionKey"
+        );
+
+        _logger.LogInitializeEnsureContainerExists("rate-limit", "lyrics-analyzer");
+        await lyricsAnalyzerDb.CreateContainerIfNotExistsAsync(
+            id: "rate-limit",
+            partitionKeyPath: "/partitionKey"
+        );
     }
 
     /// <inheritdoc cref="IDisposable.Dispose"/>

--- a/src/App/Services/CosmosDbService/LyricsAnalyzer/GetLyricsAnalyzerUserRateLimitAsync.cs
+++ b/src/App/Services/CosmosDbService/LyricsAnalyzer/GetLyricsAnalyzerUserRateLimitAsync.cs
@@ -16,7 +16,7 @@ public partial class CosmosDbService
     /// </summary>
     /// <param name="userId">The ID of the user.</param>
     /// <returns>The retrieved lyrics analyzer rate limit for the user.</returns>
-    public async Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(ulong userId) => await GetLyricsAnalyzerUserRateLimitAsync(userId, null);
+    public async Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(string userId) => await GetLyricsAnalyzerUserRateLimitAsync(userId, null);
 
     /// <summary>
     /// Gets the lyrics analyzer rate limit for a user from the database.
@@ -24,7 +24,7 @@ public partial class CosmosDbService
     /// <param name="userId">The ID of the user.</param>
     /// <param name="parentActivityId">The parent activity ID.</param>
     /// <returns>The retrieved lyrics analyzer rate limit for the user.</returns>
-    public async Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(ulong userId, string? parentActivityId)
+    public async Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(string userId, string? parentActivityId)
     {
         using var activity = _activitySource.StartDbGetLyricsAnalyzerUserRateLimitActivity(
             userId: userId,

--- a/src/App/Services/CosmosDbService/interfaces/ICosmosDbService.cs
+++ b/src/App/Services/CosmosDbService/interfaces/ICosmosDbService.cs
@@ -4,6 +4,8 @@ namespace MuzakBot.App.Services;
 
 public interface ICosmosDbService : IDisposable
 {
+    Task InitializeDatabaseAsync();
+
     Task<LyricsAnalyzerConfig> GetLyricsAnalyzerConfigAsync();
     Task<LyricsAnalyzerConfig> GetLyricsAnalyzerConfigAsync(string? parentActivityId);
 

--- a/src/App/Services/CosmosDbService/interfaces/ICosmosDbService.cs
+++ b/src/App/Services/CosmosDbService/interfaces/ICosmosDbService.cs
@@ -12,8 +12,8 @@ public interface ICosmosDbService : IDisposable
     Task AddOrUpdateLyricsAnalyzerConfigAsync(LyricsAnalyzerConfig lyricsAnalyzerConfig);
     Task AddOrUpdateLyricsAnalyzerConfigAsync(LyricsAnalyzerConfig lyricsAnalyzerConfig, string? parentActivityId);
 
-    Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(ulong userId);
-    Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(ulong userId, string? parentActivityId);
+    Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(string userId);
+    Task<LyricsAnalyzerUserRateLimit> GetLyricsAnalyzerUserRateLimitAsync(string userId, string? parentActivityId);
 
     Task AddOrUpdateLyricsAnalyzerUserRateLimitAsync(LyricsAnalyzerUserRateLimit lyricsAnalyzerUserRateLimit);
     Task AddOrUpdateLyricsAnalyzerUserRateLimitAsync(LyricsAnalyzerUserRateLimit lyricsAnalyzerUserRateLimit, string? parentActivityId);


### PR DESCRIPTION
## Description

This PR fixes a bug with how rate limits are tracked for the lyrics analyzer command.

Every now and then, the user ID property would not be serialized correctly as a `ulong` type. Seems like it was on the CosmosDB side and not directly in the code? What I ended up doing to fix it was changing the type from `ulong` to `string`.

In addition, I added an intialization step for the `CosmosDbService` to ensure that the database and containers exist and, if they don't, to create them at startup. Needed this for locally testing the changes.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- Closes #62
