### PR TITLE
Add lyrics analyzer rate limit user ignore

### DIFF
--- a/src/App/Models/Database/LyricsAnalyzer/LyricsAnalyzerConfig.cs
+++ b/src/App/Models/Database/LyricsAnalyzer/LyricsAnalyzerConfig.cs
@@ -41,7 +41,7 @@ public class LyricsAnalyzerConfig : DatabaseItem, ILyricsAnalyzerConfig
     /// Users to ignore when rate limiting.
     /// </summary>
     [JsonPropertyName("rateLimitIgnoredUserIds")]
-    public List<ulong>? RateLimitIgnoredUserIds { get; set; }
+    public List<string>? RateLimitIgnoredUserIds { get; set; }
 
     /// <summary>
     /// Whether or not the lyrics analyzer is enabled only to specific guilds/servers.

--- a/src/App/Models/Database/LyricsAnalyzer/interface/ILyricsAnalyzerConfig.cs
+++ b/src/App/Models/Database/LyricsAnalyzer/interface/ILyricsAnalyzerConfig.cs
@@ -6,7 +6,7 @@ public interface ILyricsAnalyzerConfig
     string PartitionKey { get; set; }
     bool RateLimitEnabled { get; set; }
     int RateLimitMaxRequests { get; set; }
-    List<ulong>? RateLimitIgnoredUserIds { get; set; }
+    List<string>? RateLimitIgnoredUserIds { get; set; }
     bool CommandIsEnabledToSpecificGuilds { get; set; }
     List<ulong>? CommandEnabledGuildIds { get; set; }
     List<ulong>? CommandDisabledGuildIds { get; set; }

--- a/src/App/Modules/AdminCommandModule/Commands/HandleAddUserToLyricsAnalyzerRateLimitIgnoreAsync.cs
+++ b/src/App/Modules/AdminCommandModule/Commands/HandleAddUserToLyricsAnalyzerRateLimitIgnoreAsync.cs
@@ -1,0 +1,134 @@
+using Discord;
+using Discord.Interactions;
+using Microsoft.Extensions.Logging;
+using MuzakBot.App.Models.CommandModules;
+using MuzakBot.App.Models.Database.LyricsAnalyzer;
+
+namespace MuzakBot.App.Modules;
+
+public partial class AdminCommandModule
+{
+    [SlashCommand(name: "la-ratelimit-ignore", description: "Add or remove a user from the rate limit ignore list.")]
+    [RequireOwner]
+    public async Task HandleAddUserToLyricsAnalyzerRateLimitIgnoreAsync(
+        [Summary(name: "userId", description: "The user to add to the rate limit ignore list.")]
+        string userId,
+        [Summary(name: "operation", description: "Whether to add or remove the user from the rate limit ignore list."),
+        Choice(name: "Add", value: "add"),
+        Choice(name: "Remove", value: "remove")]
+        string operation = "add"
+    )
+    {
+        await DeferAsync(
+            ephemeral: true
+        );
+
+        EmbedBuilder embedBuilder = new();
+
+        IUser user;
+        try
+        {
+            user = await _discordSocketClient.GetUserAsync(ulong.Parse(userId));
+        }
+        catch (Exception ex)
+        {
+            embedBuilder
+                .WithTitle("Lyrics Analyzer Rate Limit Ignore")
+                .WithDescription($"An error occurred while adding the user to the rate limit ignore list:\n\n{ex.Message}")
+                .WithColor(Color.Red);
+
+            await FollowupAsync(
+                embeds: [
+                    embedBuilder.Build()
+                ]
+            );
+
+            _logger.LogError(ex, "An error occurred while adding the user to the rate limit ignore list: {Message}", ex.Message);
+
+            return;
+        }
+
+        LyricsAnalyzerConfig lyricsAnalyzerConfig = await _cosmosDbService.GetLyricsAnalyzerConfigAsync();
+
+        if (lyricsAnalyzerConfig.RateLimitIgnoredUserIds is null)
+        {
+            _logger.LogInformation("Rate limit ignored user IDs list is null, initializing to empty list.");
+            lyricsAnalyzerConfig.RateLimitIgnoredUserIds = new();
+        }
+
+        if (operation == "add")
+        {
+            if (lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Contains(user.Id.ToString()))
+            {
+                _logger.LogWarning("{Username} is already on the rate limit ignore list.", user.Username);
+                embedBuilder
+                    .WithTitle("Lyrics Analyzer Rate Limit Ignore")
+                    .WithDescription($"The user `{user.Username}` is already on the rate limit ignore list.")
+                    .WithColor(Color.Red);
+
+                await FollowupAsync(
+                    embeds: [
+                        embedBuilder.Build()
+                    ]
+                );
+
+                return;
+            }
+
+            lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Add(user.Id.ToString());
+            await _cosmosDbService.AddOrUpdateLyricsAnalyzerConfigAsync(lyricsAnalyzerConfig);
+
+            _logger.LogInformation("{Username} has been added to the rate limit ignore list.", user.Username);
+
+            embedBuilder
+                .WithTitle("Lyrics Analyzer Rate Limit Ignore")
+                .WithDescription($"The user `{user.Username}` has been added to the rate limit ignore list.")
+                .WithColor(Color.Green);
+
+            await FollowupAsync(
+                embeds: [
+                    embedBuilder.Build()
+                ]
+            );
+
+            return;
+        }
+        else if (operation == "remove")
+        {
+            if (!lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Contains(user.Id.ToString()))
+            {
+                _logger.LogWarning("{Username} is not on the rate limit ignore list.", user.Username);
+                embedBuilder
+                    .WithTitle("Lyrics Analyzer Rate Limit Ignore")
+                    .WithDescription($"The user `{user.Username}` is not on the rate limit ignore list.")
+                    .WithColor(Color.Red);
+
+                await FollowupAsync(
+                    embeds: [
+                        embedBuilder.Build()
+                    ]
+                );
+
+                return;
+            }
+
+            lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Remove(user.Id.ToString());
+            await _cosmosDbService.AddOrUpdateLyricsAnalyzerConfigAsync(lyricsAnalyzerConfig);
+
+            _logger.LogInformation("{Username} has been removed from the rate limit ignore list.", user.Username);
+
+            embedBuilder
+                .WithTitle("Lyrics Analyzer Rate Limit Ignore")
+                .WithDescription($"The user `{user.Username}` has been removed from the rate limit ignore list.")
+                .WithColor(Color.Green);
+
+            await FollowupAsync(
+                embeds: [
+                    embedBuilder.Build()
+                ]
+            );
+
+            return;
+        }
+    }
+}

--- a/src/App/Modules/LyricsAnalyzerCommandModule/Commands/HandleLyricsAnalyzerAsync.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Commands/HandleLyricsAnalyzerAsync.cs
@@ -95,8 +95,10 @@ public partial class LyricsAnalyzerCommandModule
             return;
         }
 
+        bool userIsOnRateLimitIgnoreList = lyricsAnalyzerConfig.RateLimitIgnoredUserIds is not null && lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Contains(Context.User.Id.ToString());
+
         LyricsAnalyzerUserRateLimit? lyricsAnalyzerUserRateLimit = null;
-        if (lyricsAnalyzerConfig.RateLimitEnabled)
+        if (lyricsAnalyzerConfig.RateLimitEnabled && !userIsOnRateLimitIgnoreList)
         {
             _logger.LogInformation("Getting current rate limit for user '{UserId}' from database.", Context.User.Id);
             lyricsAnalyzerUserRateLimit = await _cosmosDbService.GetLyricsAnalyzerUserRateLimitAsync(Context.User.Id.ToString(), activity?.Id);
@@ -304,7 +306,7 @@ public partial class LyricsAnalyzerCommandModule
                 ephemeral: isPrivateResponse
             );
 
-            if (lyricsAnalyzerConfig.RateLimitEnabled)
+            if (lyricsAnalyzerConfig.RateLimitEnabled && !userIsOnRateLimitIgnoreList)
             {
                 _logger.LogInformation("Updating rate limit for user '{UserId}' in database.", Context.User.Id);
                 lyricsAnalyzerUserRateLimit!.IncrementRequestCount();


### PR DESCRIPTION
## Description

This PR adds a new slash command for maintaining users who won't be affected by the daily rate limits for the lyrics analyzer command.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
