### PR TITLE
Fix incorrect lyrics analyzer telemetry tag

### DIFF
--- a/src/App/Extensions/LyricsAnalyzerCommandModuleActivityExtensions.cs
+++ b/src/App/Extensions/LyricsAnalyzerCommandModuleActivityExtensions.cs
@@ -26,7 +26,7 @@ internal static class LyricsAnalyzerCommandModuleActivityExtensions
                 tags: new ActivityTagsCollection
                 {
                     { "command_Type", "SlashCommand"},
-                    { "command_Name", "getsonglyrics" },
+                    { "command_Name", "lyricsanalyzer" },
                     { "artist_Name", artistName },
                     { "song_Name", songName },
                     { "user_Id", context.User.Id },
@@ -42,7 +42,7 @@ internal static class LyricsAnalyzerCommandModuleActivityExtensions
                 tags: new ActivityTagsCollection
                 {
                 { "command_Type", "SlashCommand"},
-                { "command_Name", "getsonglyrics" },
+                { "command_Name", "lyricsanalyzer" },
                 { "artist_Name", artistName },
                 { "song_Name", songName },
                 { "guild_Id", context.Guild.Id },


### PR DESCRIPTION
## Description

This PR fixes the `command_Name` tag for the lyrics analyzer command's activity.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
