### PR TITLE
Change model to 'gpt-4-turbo-preview'

### DIFF
--- a/src/App/Services/OpenAiService/OpenAiService.cs
+++ b/src/App/Services/OpenAiService/OpenAiService.cs
@@ -69,7 +69,7 @@ public partial class OpenAiService : IOpenAiService
 
         OpenAiChatCompletionRequest request = new()
         {
-            Model = "gpt-4-1106-preview",
+            Model = "gpt-4-turbo-preview",
             Temperature = 1,
             MaxTokens = 512,
             TopP = 1,


### PR DESCRIPTION
## Description

This PR changes the GPT4 model from `gpt-4-1106-preview` to `gpt-4-turbo-preview`. This should keep the GPT4 Turbo preview model up-to-date as new versions are made available.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
