### PR TITLE
Remove interaction success logs

### DIFF
--- a/src/App/Services/DiscordService/DiscordService.cs
+++ b/src/App/Services/DiscordService/DiscordService.cs
@@ -151,10 +151,6 @@ public class DiscordService : IDiscordService, IHostedService
             _logger.LogFailedToExecuteInteraction(interaction.User.Username, interaction.IsDMInteraction);
             _logger.LogInteractionErrorMessage(result.ErrorReason);
         }
-        else
-        {
-            _logger.LogSuccessfullyExecutedInteraction(interaction.User.Username, interaction.IsDMInteraction);
-        }
     }
 
     /// <summary>
@@ -171,10 +167,6 @@ public class DiscordService : IDiscordService, IHostedService
         {
             _logger.LogFailedToExecuteSlashCommand(interaction.User.Username, interaction.IsDMInteraction);
             _logger.LogSlashCommandErrorMessage(result.ErrorReason);
-        }
-        else
-        {
-            _logger.LogSuccessfullyExecutedSlashCommand(interaction.User.Username, interaction.IsDMInteraction);
         }
     }
 
@@ -193,10 +185,6 @@ public class DiscordService : IDiscordService, IHostedService
         {
             _logger.LogFailedToExecuteAutocomplete(interaction.User.Username, interaction.IsDMInteraction);
             _logger.LogAutocompleteErrorMessage(result.ErrorReason);
-        }
-        else
-        {
-            _logger.LogSuccessfullyExecutedAutocomplete(interaction.User.Username, interaction.IsDMInteraction);
         }
     }
 


### PR DESCRIPTION
## Description

This PR removes the success logging for the following interactions:

- Generic interaction
- Slash
- Autocomplete

This should reduce the amount of logging generated for any interaction, since it would constantly flood it with unnecessary logging.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
