### PR TITLE
Revert from chiseled .NET 8 container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN dotnet publish --configuration "Release" --os "${TARGETOS}" --arch "${TARGET
 RUN rm -rf /app/artifacts/publish/App/release/*.pdb; \
     rm -rf /app/artifacts/publish/App/release/*.dbg
 
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/runtime:8.0
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Description

This PR reverts the .NET 8 container image from chiseled to the regular runtime image.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
