### PR TITLE
Fix type mismatch for Bandcamp entities in Odesli API outputs

### DIFF
--- a/src/Lib/Models/Json/JsonNumberToStringConverter.cs
+++ b/src/Lib/Models/Json/JsonNumberToStringConverter.cs
@@ -1,0 +1,24 @@
+namespace MuzakBot.Lib.Models.Json;
+
+public class JsonNumberToStringConverter : JsonConverter<string>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            return reader.GetString();
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            return reader.GetDouble().ToString();
+        }
+
+        throw new JsonException("Expected number or string.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}

--- a/src/Lib/Models/Odesli/StreamingEntityItem.cs
+++ b/src/Lib/Models/Odesli/StreamingEntityItem.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using MuzakBot.Lib.Models.Json;
 
 namespace MuzakBot.Lib.Models.Odesli;
 
@@ -9,6 +10,7 @@ public class StreamingEntityItem : IStreamingEntityItem
 {
     /// <inheritdoc cref="IStreamingEntityItem.Id" />
     [JsonPropertyName("id")]
+    [JsonConverter(typeof(JsonNumberToStringConverter))]
     public string? Id { get; set; }
 
     /// <inheritdoc cref="IStreamingEntityItem.Title" />


### PR DESCRIPTION
## Description

This PR is a bug fix for a type mismatch in the Odesli API for Bandcamp entities.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- #87 
