### PR TITLE
Switch from the iTunes Store API to the Apple Music API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -35,6 +35,7 @@
         <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
         <PackageReference Include="OpenTelemetry.Exporter.Console" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/src/App/Handlers/AppleMusic/AppleMusicArtistAlbumAutocompleteHandler.cs
+++ b/src/App/Handlers/AppleMusic/AppleMusicArtistAlbumAutocompleteHandler.cs
@@ -1,0 +1,101 @@
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.Lib.Models.AppleMusic;
+using MuzakBot.Lib.Services;
+
+namespace MuzakBot.App;
+
+public class AppleMusicArtistAlbumAutocompleteHandler : AutocompleteHandler
+{
+    private readonly IAppleMusicApiService _appleMusicApiService;
+    private readonly ILogger _logger;
+
+    public AppleMusicArtistAlbumAutocompleteHandler(IAppleMusicApiService appleMusicApiService, ILogger<AppleMusicArtistAlbumAutocompleteHandler> logger)
+    {
+        _appleMusicApiService = appleMusicApiService;
+        _logger = logger;
+    }
+
+    public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
+    {
+        List<AutocompleteResult> results = [];
+
+        AutocompleteOption? artistInput = autocompleteInteraction.Data.Options.FirstOrDefault(item => item.Name == "artist-name");
+
+        Artist artist;
+        if (artistInput is null || artistInput.Value is null || string.IsNullOrWhiteSpace(artistInput.Value.ToString()))
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.BadArgs,
+                reason: "Please select an artist first. 😅"
+            );
+        }
+
+        artist = await _appleMusicApiService.GetArtistFromCatalogAsync(artistInput.Value.ToString()!);
+
+        if (autocompleteInteraction.Data is null || autocompleteInteraction.Data.Current is null || autocompleteInteraction.Data.Current.Value is null || string.IsNullOrWhiteSpace(autocompleteInteraction.Data.Current.Value.ToString()))
+        {
+            results.Add(
+                item: new(
+                    name: "Start typing a song name...",
+                    value: ""
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        Album[] albumSearchResults;
+        try
+        {
+            albumSearchResults = await _appleMusicApiService.SearchAlbumsAsync($"{artist.Attributes!.Name} {autocompleteInteraction.Data?.Current?.Value?.ToString()!}");
+        }
+        catch
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.Unsuccessful,
+                reason: "An error occurred while searching for the album. 😥"
+            );
+        }
+
+        if (albumSearchResults.Length == 0)
+        {
+            results.Add(
+                item: new(
+                    name: "No results found",
+                    value: "No results found"
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        Album[] filteredAlbums = Array.FindAll(
+            array: albumSearchResults,
+            match: album => album.Attributes!.ArtistName == artist.Attributes!.Name
+        );
+
+        if (filteredAlbums.Length == 0)
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.Unsuccessful,
+                reason: "No albums found for the selected artist. 😅"
+            );
+        }
+
+        foreach (var albumItem in filteredAlbums)
+        {
+            results.Add(
+                item: new(
+                    name: albumItem.Attributes!.Name,
+                    value: albumItem.Id
+                )
+            );
+        }
+
+        return AutocompletionResult.FromSuccess(results.AsEnumerable());
+    }
+}

--- a/src/App/Handlers/AppleMusic/AppleMusicArtistAutoCompleteHandler.cs
+++ b/src/App/Handlers/AppleMusic/AppleMusicArtistAutoCompleteHandler.cs
@@ -1,0 +1,86 @@
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.Lib.Models.AppleMusic;
+using MuzakBot.Lib.Services;
+
+namespace MuzakBot.App.Handlers;
+
+public class AppleMusicArtistAutoCompleteHandler : AutocompleteHandler
+{
+    private readonly IAppleMusicApiService _appleMusicApiService;
+    private readonly ILogger _logger;
+
+    public AppleMusicArtistAutoCompleteHandler(IAppleMusicApiService appleMusicApiService, ILogger<AppleMusicArtistAutoCompleteHandler> logger)
+    {
+        _appleMusicApiService = appleMusicApiService;
+        _logger = logger;
+    }
+
+    public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
+    {
+        List<AutocompleteResult> results = [];
+
+        if (autocompleteInteraction.Data is null || autocompleteInteraction.Data.Current is null || autocompleteInteraction.Data.Current.Value is null || string.IsNullOrWhiteSpace(autocompleteInteraction.Data.Current.Value.ToString()))
+        {
+            results.Add(
+                item: new(
+                    name: "Start typing an artist name...",
+                    value: "Start typing an artist name..."
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        Artist[] artistSearchResults;
+        try
+        {
+            artistSearchResults = await _appleMusicApiService.SearchArtistsAsync(autocompleteInteraction.Data?.Current?.Value?.ToString()!);
+        }
+        catch
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.Unsuccessful,
+                reason: "An error occurred while searching for artists. 😥"
+            );
+        }
+
+        if (artistSearchResults.Length == 0)
+        {
+            results.Add(
+                item: new(
+                    name: "No results found",
+                    value: "No results found"
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        foreach (var artistItem in artistSearchResults)
+        {
+            string primaryGenre;
+
+            try
+            {
+                primaryGenre = artistItem.Attributes!.GenreNames.First();
+            }
+            catch
+            {
+                primaryGenre = "Unknown";
+            }
+
+            results.Add(
+                item: new(
+                    name: $"{artistItem.Attributes!.Name} ({primaryGenre})",
+                    value: artistItem.Id
+                )
+            );
+        }
+
+        return AutocompletionResult.FromSuccess(results.AsEnumerable());
+    }
+}

--- a/src/App/Handlers/AppleMusic/AppleMusicArtistSongAutocompleteHandler.cs
+++ b/src/App/Handlers/AppleMusic/AppleMusicArtistSongAutocompleteHandler.cs
@@ -1,0 +1,102 @@
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.Lib.Models.AppleMusic;
+using MuzakBot.Lib.Services;
+
+namespace MuzakBot.App;
+
+public class AppleMusicArtistSongAutocompleteHandler : AutocompleteHandler
+{
+    private readonly IAppleMusicApiService _appleMusicApiService;
+    private readonly ILogger _logger;
+
+    public AppleMusicArtistSongAutocompleteHandler(IAppleMusicApiService appleMusicApiService, ILogger<AppleMusicArtistSongAutocompleteHandler> logger)
+    {
+        _appleMusicApiService = appleMusicApiService;
+        _logger = logger;
+    }
+
+    public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
+    {
+        List<AutocompleteResult> results = [];
+
+        AutocompleteOption? artistInput = autocompleteInteraction.Data.Options.FirstOrDefault(item => item.Name == "artist-name");
+
+        Artist artist;
+        if (artistInput is null || artistInput.Value is null || string.IsNullOrWhiteSpace(artistInput.Value.ToString()))
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.BadArgs,
+                reason: "Please select an artist first. 😅"
+            );
+        }
+
+        artist = await _appleMusicApiService.GetArtistFromCatalogAsync(artistInput.Value.ToString()!);
+
+        if (autocompleteInteraction.Data is null || autocompleteInteraction.Data.Current is null || autocompleteInteraction.Data.Current.Value is null || string.IsNullOrWhiteSpace(autocompleteInteraction.Data.Current.Value.ToString()))
+        {
+            results.Add(
+                item: new(
+                    name: "Start typing a song name...",
+                    value: ""
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        Song[] songSearchResults;
+        try
+        {
+            songSearchResults = await _appleMusicApiService.SearchSongsAsync($"{artist.Attributes!.Name} {autocompleteInteraction.Data?.Current?.Value?.ToString()!}");
+        }
+        catch
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.Unsuccessful,
+                reason: "An error occurred while searching for the song. 😥"
+            );
+        }
+
+        if (songSearchResults.Length == 0)
+        {
+            results.Add(
+                item: new(
+                    name: "No results found",
+                    value: "No results found"
+                )
+            );
+
+            return AutocompletionResult.FromSuccess(results.AsEnumerable());
+        }
+
+        Song[] filteredSongs = Array.FindAll(
+            array: songSearchResults,
+            match: song => song.Attributes!.ArtistName == artist.Attributes!.Name
+        );
+
+        if (filteredSongs.Length == 0)
+        {
+            return AutocompletionResult.FromError(
+                error: InteractionCommandError.Unsuccessful,
+                reason: "No songs found for the selected artist. 😅"
+            );
+        }
+
+        foreach (var songItem in filteredSongs)
+        {
+            _logger.LogInformation("Song: {SongName} - {SongId}", songItem.Attributes!.Name, songItem.Id);
+            results.Add(
+                item: new(
+                    name: songItem.Attributes!.Name,
+                    value: songItem.Id
+                )
+            );
+        }
+
+        return AutocompletionResult.FromSuccess(results.AsEnumerable());
+    }
+}

--- a/src/App/Modules/LyricsAnalyzerCommandModule/LyricsAnalyzerCommandModule.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/LyricsAnalyzerCommandModule.cs
@@ -22,6 +22,7 @@ public partial class LyricsAnalyzerCommandModule : InteractionModuleBase<SocketI
     private bool _isDisposed;
     private readonly ActivitySource _activitySource = new("MuzakBot.App.Modules.LyricsAnalyzerCommandModule");
     private readonly IMusicBrainzService _musicBrainzService;
+    private readonly IAppleMusicApiService _appleMusicApiService;
     private readonly IGeniusApiService _geniusApiService;
     private readonly IOpenAiService _openAiService;
     private readonly ICosmosDbService _cosmosDbService;
@@ -38,9 +39,10 @@ public partial class LyricsAnalyzerCommandModule : InteractionModuleBase<SocketI
     /// <param name="openAiService">The <see cref="IOpenAiService"/>.</param>
     /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/>.</param>
     /// <param name="logger">The logger.</param>
-    public LyricsAnalyzerCommandModule(IMusicBrainzService musicBrainzService, IGeniusApiService geniusApiService, IOpenAiService openAiService, ICosmosDbService cosmosDbService, IDbContextFactory<SongLyricsDbContext> songLyricsDbContextFactory, IQueueClientService queueClientService, IHttpClientFactory httpClientFactory, ILogger<LyricsAnalyzerCommandModule> logger)
+    public LyricsAnalyzerCommandModule(IMusicBrainzService musicBrainzService, IAppleMusicApiService appleMusicApiService, IGeniusApiService geniusApiService, IOpenAiService openAiService, ICosmosDbService cosmosDbService, IDbContextFactory<SongLyricsDbContext> songLyricsDbContextFactory, IQueueClientService queueClientService, IHttpClientFactory httpClientFactory, ILogger<LyricsAnalyzerCommandModule> logger)
     {
         _musicBrainzService = musicBrainzService;
+        _appleMusicApiService = appleMusicApiService;
         _geniusApiService = geniusApiService;
         _openAiService = openAiService;
         _cosmosDbService = cosmosDbService;

--- a/src/App/Modules/ShareMusicCommandModule/ShareMusicCommandModule.cs
+++ b/src/App/Modules/ShareMusicCommandModule/ShareMusicCommandModule.cs
@@ -19,15 +19,17 @@ public partial class ShareMusicCommandModule : InteractionModuleBase<SocketInter
     private readonly ActivitySource _activitySource = new("MuzakBot.App.Modules.ShareMusicCommandModule");
     private readonly IOdesliService _odesliService;
     private readonly IItunesApiService _itunesApiService;
+    private readonly IAppleMusicApiService _appleMusicApiService;
     private readonly IMusicBrainzService _musicBrainzService;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<ShareMusicCommandModule> _logger;
     private readonly CommandMetrics _commandMetrics;
 
-    public ShareMusicCommandModule(IOdesliService odesliService, IItunesApiService itunesApiService, IMusicBrainzService musicBrainzService, IHttpClientFactory httpClientFactory, ILogger<ShareMusicCommandModule> logger, CommandMetrics commandMetrics)
+    public ShareMusicCommandModule(IOdesliService odesliService, IItunesApiService itunesApiService, IAppleMusicApiService appleMusicApiService, IMusicBrainzService musicBrainzService, IHttpClientFactory httpClientFactory, ILogger<ShareMusicCommandModule> logger, CommandMetrics commandMetrics)
     {
         _odesliService = odesliService;
         _itunesApiService = itunesApiService;
+        _appleMusicApiService = appleMusicApiService;
         _musicBrainzService = musicBrainzService;
         _httpClientFactory = httpClientFactory;
         _logger = logger;

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleFindAlbumAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleFindAlbumAsync.cs
@@ -1,11 +1,15 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+
 using Discord;
 using Discord.Interactions;
+
 using Microsoft.Extensions.Logging;
+
 using MuzakBot.App.Extensions;
 using MuzakBot.App.Handlers;
+using MuzakBot.Lib.Models.AppleMusic;
 using MuzakBot.Lib.Models.Itunes;
 using MuzakBot.Lib.Models.MusicBrainz;
 using MuzakBot.Lib.Models.Odesli;
@@ -22,11 +26,11 @@ public partial class ShareMusicCommandModule
     )]
     private async Task HandleFindAlbumAsync(
         [Summary("artistName", "The name of an artist"),
-         Autocomplete(typeof(ArtistSearchAutoCompleteHandler))
+         Autocomplete(typeof(AppleMusicArtistAutoCompleteHandler))
         ]
         string artistId,
         [Summary(name: "albumName", description: "The name of an album"),
-         Autocomplete(typeof(ArtistAlbumSearchAutoCompleteHandler))
+         Autocomplete(typeof(AppleMusicArtistAlbumAutocompleteHandler))
         ]
         string albumId
     )
@@ -37,10 +41,10 @@ public partial class ShareMusicCommandModule
         {
             await DeferAsync();
 
-            MusicBrainzArtistItem? artistItem = null;
+            Artist? artistItem = null;
             try
             {
-                artistItem = await _musicBrainzService.LookupArtistAsync(artistId, activity?.Id);
+                artistItem = await _appleMusicApiService.GetArtistFromCatalogAsync(artistId);
             }
             catch (Exception ex)
             {
@@ -55,15 +59,15 @@ public partial class ShareMusicCommandModule
                 return;
             }
 
-            MusicBrainzReleaseItem? releaseItem = null;
+            Album? albumItem = null;
 
             try
             {
-                releaseItem = await _musicBrainzService.LookupReleaseAsync(albumId, activity?.Id);
+                albumItem = await _appleMusicApiService.GetAlbumFromCatalogAsync(albumId);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error looking up album '{songId}'.", albumId);
+                _logger.LogError(ex, "Error looking up album '{albumId}'.", albumId);
                 await FollowupAsync(
                     embed: GenerateErrorEmbed("An error occurred while looking up the album. 😥").Build(),
                     components: GenerateRemoveComponent().Build()
@@ -74,7 +78,7 @@ public partial class ShareMusicCommandModule
                 return;
             }
 
-            if (artistItem is null || releaseItem is null)
+            if (artistItem is null || albumItem is null)
             {
                 await FollowupAsync(
                     embed: GenerateErrorEmbed("No results found for that artist and album. 😥").Build(),
@@ -86,29 +90,12 @@ public partial class ShareMusicCommandModule
                 return;
             }
 
-            ApiSearchResult<AlbumItem>? apiSearchResult = await _itunesApiService.GetAlbumsByArtistResultAsync(artistItem!.Name, releaseItem!.Title, activity?.Id);
-
-            if (apiSearchResult is null || apiSearchResult.Results is null || apiSearchResult.Results.Length == 0)
-            {
-                await FollowupAsync(
-                    embed: GenerateErrorEmbed("No results were found.").Build(),
-                    components: GenerateRemoveComponent().Build()
-                );
-
-                activity?.SetStatus(ActivityStatusCode.Error);
-
-                return;
-            }
-
-
-            AlbumItem albumItem = apiSearchResult.Results[0];
-
-            _logger.LogInformation("Selected album '{albumName}' by '{artistName}'.", albumItem.CollectionName, albumItem.ArtistName);
+            _logger.LogInformation("Selected album '{albumName}' by '{artistName}'.", albumItem.Attributes!.Name, albumItem.Attributes!.ArtistName);
 
             MusicEntityItem? musicEntityItem = null;
             try
             {
-                musicEntityItem = await _odesliService.GetShareLinksAsync(albumItem.CollectionViewUrl);
+                musicEntityItem = await _odesliService.GetShareLinksAsync(albumItem.Attributes!.Url);
 
                 if (musicEntityItem is null)
                 {
@@ -117,7 +104,7 @@ public partial class ShareMusicCommandModule
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "No share links found for '{url}'.", albumItem.CollectionViewUrl);
+                _logger.LogError(e, "No share links found for '{url}'.", albumItem.Attributes!.Url);
                 await FollowupAsync(
                     embed: GenerateErrorEmbed("No share links were found. 😥").Build(),
                     components: GenerateRemoveComponent().Build()
@@ -150,7 +137,7 @@ public partial class ShareMusicCommandModule
                 }
                 else
                 {
-                    _logger.LogError("Could get all of the necessary data for '{url}'.", albumItem.CollectionViewUrl);
+                    _logger.LogError("Could get all of the necessary data for '{url}'.", albumItem.Attributes.Url);
                     await FollowupAsync(
                         embed: GenerateErrorEmbed("I was unable to get the necessary information from Odesli. 😥").Build(),
                         components: GenerateRemoveComponent().Build()

--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleSearchArtistAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleSearchArtistAsync.cs
@@ -1,0 +1,97 @@
+using System.Text;
+
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.App.Handlers;
+using MuzakBot.Lib.Models.AppleMusic;
+
+namespace MuzakBot.App.Modules;
+
+public partial class ShareMusicCommandModule
+{
+    [CommandContextType(InteractionContextType.BotDm, InteractionContextType.PrivateChannel, InteractionContextType.Guild)]
+    [IntegrationType(ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall)]
+    [SlashCommand(
+        name: "searchartist",
+        description: "Find an album from an artist"
+    )]
+    private async Task HandleSearchArtistAsync(
+        [Summary(
+            name: "searchTerm",
+            description: "The search term for the search."
+        ),
+        Autocomplete(typeof(AppleMusicArtistAutoCompleteHandler))]
+        string searchTerm
+    )
+    {
+        await DeferAsync();
+
+        Artist artist;
+
+        try
+        {
+            artist = await _appleMusicApiService.GetArtistFromCatalogAsync(searchTerm);
+        }
+        catch
+        {
+            await FollowupAsync(
+                text: "An error occurred while searching for the artist. 😥"
+            );
+
+            return;
+        }
+
+        StringBuilder outputResponseBuilder = new($"# {artist.Attributes!.Name}\n");
+
+        outputResponseBuilder.AppendLine("## Genres\n");
+        if (artist.Attributes!.GenreNames is not null && artist.Attributes!.GenreNames.Length > 0)
+        {
+            foreach (string genre in artist.Attributes!.GenreNames)
+            {
+                outputResponseBuilder.AppendLine($"- {genre}");
+            }
+        }
+        else
+        {
+            outputResponseBuilder.AppendLine("- No genres found.");
+        }
+
+        if (artist.Attributes!.Artwork is null)
+        {
+            await FollowupAsync(
+                text: outputResponseBuilder.ToString()
+            );
+
+            return;
+        }
+        else
+        {
+            var httpClient = _httpClientFactory.CreateClient("GenericClient");
+
+            string artworkUrl = artist.Attributes!.Artwork
+                .Url
+                .Replace("{w}", (artist.Attributes!.Artwork.Width / 2).ToString())
+                .Replace("{h}", (artist.Attributes!.Artwork.Height / 2).ToString());
+
+            _logger.LogInformation("Getting {artworkUrl}.", artworkUrl);
+
+            HttpResponseMessage responseMessage = await httpClient.GetAsync(artworkUrl);
+
+            var embedBuilder = new EmbedBuilder()
+                .WithImageUrl($"attachment://{artist.Id}.jpg")
+                .WithColor(Color.DarkBlue);
+
+            await FollowupWithFileAsync(
+                text: outputResponseBuilder.ToString(),
+                fileStream: await responseMessage.Content.ReadAsStreamAsync(),
+                fileName: $"{artist.Id}.jpg",
+                embed: embedBuilder.Build()
+            );
+
+            return;
+        }
+    }
+}

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -64,6 +64,15 @@ builder.Services
     .AddItunesApiService()
     .AddMusicBrainzService();
 
+builder.Services
+    .AddAppleMusicApiService(options =>
+    {
+        options.AppleTeamId = builder.Configuration.GetValue<string>("APPLE_TEAM_ID") ?? throw new("APPLE_TEAM_ID is not set.");
+        options.AppleAppId = builder.Configuration.GetValue<string>("APPLE_APP_ID") ?? throw new("APPLE_APP_ID is not set.");
+        options.AppleAppKeyId = builder.Configuration.GetValue<string>("APPLE_APP_KEY_ID") ?? throw new("APPLE_APP_KEY_ID is not set");
+        options.AppleAppKey = builder.Configuration.GetValue<string>("APPLE_APP_KEY") ?? throw new("APPLE_APP_KEY is not set.");
+    });
+
 DatabaseConfig databaseConfig = builder.Configuration.GetDatabaseConfig();
 
 builder.Services

--- a/src/Lib.Services/Extensions/ServiceSetup/AppleMusicApiServiceSetupExtensions.cs
+++ b/src/Lib.Services/Extensions/ServiceSetup/AppleMusicApiServiceSetupExtensions.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MuzakBot.Lib.Services.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceCollection"/> to add <see cref="AppleMusicApiService"/>.
+/// </summary>
+public static class AppleMusicApiServiceSetupExtensions
+{
+    /// <summary>
+    /// Add the <see cref="AppleMusicApiService"/> to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <param name="options">An action to configure <see cref="AppleMusicApiService"/>.</param>
+    /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddAppleMusicApiService(this IServiceCollection services, Action<AppleMusicApiServiceOptions> options)
+    {
+        services.Configure(options);
+
+        services.AddHttpClient(
+            name: "AppleMusicApiClient",
+            configureClient: (serviceProvider, httpClient) =>
+            {
+                httpClient.DefaultRequestHeaders.UserAgent.Add(new("MuzakBot", Assembly.GetExecutingAssembly().GetName().Version!.ToString()));
+                httpClient.BaseAddress = new("https://api.music.apple.com/");
+            }
+        );
+
+        services.AddSingleton<IAppleMusicApiService, AppleMusicApiService>();
+
+        return services;
+    }
+}

--- a/src/Lib.Services/JsonSourceGen/AppleMusicApiJsonContext.cs
+++ b/src/Lib.Services/JsonSourceGen/AppleMusicApiJsonContext.cs
@@ -23,12 +23,11 @@ namespace MuzakBot.Lib.Services;
 [JsonSerializable(typeof(AppleMusicResponse<Artist>))]
 [JsonSerializable(typeof(AppleMusicResponse<Song>))]
 [JsonSerializable(typeof(AppleMusicResponse<Album>))]
-[JsonSerializable(typeof(SearchResponse<Artist>))]
-[JsonSerializable(typeof(SearchResponse<Song>))]
-[JsonSerializable(typeof(SearchResponse<Album>))]
-[JsonSerializable(typeof(SearchResponseResults<Artist>))]
-[JsonSerializable(typeof(SearchResponseResults<Song>))]
-[JsonSerializable(typeof(SearchResponseResults<Album>))]
+[JsonSerializable(typeof(SearchResponse))]
+[JsonSerializable(typeof(SearchResponseResults))]
+[JsonSerializable(typeof(SearchResponseResultsData<Artist>))]
+[JsonSerializable(typeof(SearchResponseResultsData<Song>))]
+[JsonSerializable(typeof(SearchResponseResultsData<Album>))]
 internal partial class AppleMusicApiJsonContext : JsonSerializerContext
 {
 }

--- a/src/Lib.Services/JsonSourceGen/AppleMusicApiJsonContext.cs
+++ b/src/Lib.Services/JsonSourceGen/AppleMusicApiJsonContext.cs
@@ -1,0 +1,34 @@
+using MuzakBot.Lib.Models.AppleMusic;
+
+namespace MuzakBot.Lib.Services;
+
+/// <summary>
+/// JSON source generation context for the Apple Music API classes.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Default,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+)]
+[JsonSerializable(typeof(Artist))]
+[JsonSerializable(typeof(Artist[]))]
+[JsonSerializable(typeof(ArtistAttributes))]
+[JsonSerializable(typeof(Song))]
+[JsonSerializable(typeof(Song[]))]
+[JsonSerializable(typeof(SongAttributes))]
+[JsonSerializable(typeof(Album))]
+[JsonSerializable(typeof(Album[]))]
+[JsonSerializable(typeof(AlbumAttributes))]
+[JsonSerializable(typeof(AppleMusicResponse<Artist>))]
+[JsonSerializable(typeof(AppleMusicResponse<Song>))]
+[JsonSerializable(typeof(AppleMusicResponse<Album>))]
+[JsonSerializable(typeof(SearchResponse<Artist>))]
+[JsonSerializable(typeof(SearchResponse<Song>))]
+[JsonSerializable(typeof(SearchResponse<Album>))]
+[JsonSerializable(typeof(SearchResponseResults<Artist>))]
+[JsonSerializable(typeof(SearchResponseResults<Song>))]
+[JsonSerializable(typeof(SearchResponseResults<Album>))]
+internal partial class AppleMusicApiJsonContext : JsonSerializerContext
+{
+}

--- a/src/Lib.Services/Lib.Services.csproj
+++ b/src/Lib.Services/Lib.Services.csproj
@@ -1,41 +1,35 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RootNamespace>MuzakBot.Lib.Services</RootNamespace>
-    <AssemblyName>MuzakBot.Lib.Services</AssemblyName>
-    <PackageId>MuzakBot.Lib.Services</PackageId>
-
-    <Description>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	</PropertyGroup>
+	<PropertyGroup>
+		<RootNamespace>MuzakBot.Lib.Services</RootNamespace>
+		<AssemblyName>MuzakBot.Lib.Services</AssemblyName>
+		<PackageId>MuzakBot.Lib.Services</PackageId>
+		<Description>
       Class library for MuzakBot services.
     </Description>
-
-    <Authors>Timothy Small</Authors>
-    <Company>Smalls.Online</Company>
-    <Copyright>© Smalls.Online</Copyright>
-
-    <RepositoryUrl>https://github.com/Smalls1652/MuzakBot</RepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" PrivateAssets="all"/>
-    <PackageReference Include="Azure.Storage.Queues" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.Azure.Cosmos" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Logging" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" PrivateAssets="all" />
-    <PackageReference Include="OpenTelemetry" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Lib\Lib.csproj" />
-  </ItemGroup>
-
+		<Authors>Timothy Small</Authors>
+		<Company>Smalls.Online</Company>
+		<Copyright>© Smalls.Online</Copyright>
+		<RepositoryUrl>https://github.com/Smalls1652/MuzakBot</RepositoryUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Azure.Identity" PrivateAssets="all" />
+		<PackageReference Include="Azure.Storage.Queues" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Extensions.Logging" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Extensions.Http" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" PrivateAssets="all" />
+		<PackageReference Include="OpenTelemetry" PrivateAssets="all" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Lib\Lib.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiService.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiService.cs
@@ -50,7 +50,7 @@ public partial class AppleMusicApiService : IAppleMusicApiService
             searchTypes: [
                 SearchType.Artists
             ],
-            limit: 10
+            limit: 5
         );
 
         try

--- a/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiService.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiService.cs
@@ -1,0 +1,198 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+using MuzakBot.Lib.Models.AppleMusic;
+
+namespace MuzakBot.Lib.Services;
+
+/// <summary>
+/// Service for interacting with the Apple Music API.
+/// </summary>
+public partial class AppleMusicApiService : IAppleMusicApiService
+{
+    private string? _bearerToken;
+    private bool _tokenIsBeingRefreshed = false;
+
+    private readonly AppleMusicApiServiceOptions _options;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppleMusicApiService"/> class.
+    /// </summary>
+    /// <param name="options">The options for the service.</param>
+    /// <param name="httpClientFactory">The HTTP client factory.</param>
+    /// <param name="logger">The logger.</param>
+    public AppleMusicApiService(IOptions<AppleMusicApiServiceOptions> options, IHttpClientFactory httpClientFactory, ILogger<AppleMusicApiService> logger)
+    {
+        _options = options.Value;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Search for artists on Apple Music.
+    /// </summary>
+    /// <param name="searchTerm">The search term.</param>
+    /// <returns>An array of artists.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when an error occurs deserializing the search response.</exception>
+    public async Task<Artist[]> SearchArtistsAsync(string searchTerm)
+    {
+        SearchRequest searchRequest = new(
+            storefront: "us",
+            term: searchTerm,
+            searchTypes: [
+                SearchType.Artists
+            ],
+            limit: 10
+        );
+
+        try
+        {
+            using HttpResponseMessage response = await SendRequestAsync(searchRequest);
+
+            SearchResponse<Artist> searchResponse = await JsonSerializer.DeserializeAsync(
+                utf8Json: await response.Content.ReadAsStreamAsync(),
+                jsonTypeInfo: AppleMusicApiJsonContext.Default.SearchResponseArtist
+            ) ?? throw new InvalidOperationException("Error deserializing search response.");
+
+            return searchResponse.Results.Data;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error searching for artists.");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Send a request to the Apple Music API.
+    /// </summary>
+    /// <param name="searchRequest">The search request to send.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The response from the Apple Music API.</returns>
+    private async Task<HttpResponseMessage> SendRequestAsync(SearchRequest searchRequest, CancellationToken cancellationToken = default)
+    {
+        if (_tokenIsBeingRefreshed)
+        {
+            _logger.LogWarning("Token is being refreshed. Waiting for refresh to complete.");
+            while (_tokenIsBeingRefreshed)
+            {
+                await Task.Delay(1000, cancellationToken);
+            }
+        }
+
+        if (_bearerToken is null || string.IsNullOrWhiteSpace(_bearerToken) || IsTokenExpired())
+        {
+            GenerateBearerToken();
+        }
+
+        using HttpClient client = _httpClientFactory.CreateClient("AppleMusicApiClient");
+
+        using HttpRequestMessage requestMessage = new(
+            method: HttpMethod.Get,
+            requestUri: searchRequest.CreateUrlPath()
+        );
+
+        requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _bearerToken);
+
+        HttpResponseMessage response = await client.SendAsync(requestMessage, cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        return response;
+    }
+
+    /// <summary>
+    /// Generate a bearer token for the Apple Music API.
+    /// </summary>
+    private void GenerateBearerToken()
+    {
+        if (!IsTokenExpired())
+        {
+            return;
+        }
+
+        _tokenIsBeingRefreshed = true;
+
+        _logger.LogInformation("Generating bearer token.");
+        try
+        {
+            using CngKey privateKey = CngKey.Import(
+                keyBlob: _options.ConvertAppKeyToByteArray(),
+                format: CngKeyBlobFormat.Pkcs8PrivateBlob
+            );
+
+            using ECDsaCng appKey = new(privateKey)
+            {
+                HashAlgorithm = CngAlgorithm.Sha256
+            };
+
+            ECDsaSecurityKey securityKey = new(appKey)
+            {
+                KeyId = _options.AppleAppKeyId
+            };
+
+            SigningCredentials signingCredentials = new(
+                key: securityKey,
+                algorithm: SecurityAlgorithms.EcdsaSha256
+            );
+
+            JsonWebTokenHandler tokenHandler = new();
+
+            SecurityTokenDescriptor tokenDescriptor = new()
+            {
+                Issuer = _options.AppleTeamId,
+                IssuedAt = DateTime.UtcNow,
+                Expires = DateTime.UtcNow.AddMinutes(_options.TokenExpiration.TotalMinutes),
+                SigningCredentials = signingCredentials
+            };
+
+            string token = tokenHandler.CreateToken(tokenDescriptor);
+
+            _bearerToken = token;
+        }
+        finally
+        {
+            _tokenIsBeingRefreshed = false;
+        }
+    }
+
+    /// <summary>
+    /// Check if the token is expired.
+    /// </summary>
+    /// <returns>True if the token is expired, false otherwise.</returns>
+    private bool IsTokenExpired()
+    {
+        if (_bearerToken is null || string.IsNullOrWhiteSpace(_bearerToken))
+        {
+            return true;
+        }
+
+        JsonWebTokenHandler tokenHandler = new();
+
+        try
+        {
+            JsonWebToken jwt = tokenHandler.ReadJsonWebToken(_bearerToken);
+            bool isExpired = jwt.ValidTo < DateTime.UtcNow;
+
+            if (isExpired)
+            {
+                _logger.LogWarning("Token is expired.");
+            }
+
+            return isExpired;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error reading JWT");
+            return true;
+        }
+    }
+}

--- a/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiServiceOptions.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiServiceOptions.cs
@@ -1,0 +1,65 @@
+using System.Text.RegularExpressions;
+
+namespace MuzakBot.Lib.Services;
+
+/// <summary>
+/// Options for configuring <see cref="AppleMusicApiService"/>.
+/// </summary>
+public partial class AppleMusicApiServiceOptions
+{
+    /// <summary>
+    /// The Apple Developer team ID.
+    /// </summary>
+    public string AppleTeamId { get; set; } = null!;
+
+    /// <summary>
+    /// The app ID for the app.
+    /// </summary>
+    public string AppleAppId { get; set; } = null!;
+
+    /// <summary>
+    /// The key for the app.
+    /// </summary>
+    public string AppleAppKey { get; set; } = null!;
+
+    /// <summary>
+    /// The ID for the key.
+    /// </summary>
+    public string AppleAppKeyId { get; set; } = null!;
+
+    /// <summary>
+    /// The user token for delegating requests.
+    /// </summary>
+    public string? AppleMusicUserToken { get; set; }
+
+    /// <summary>
+    /// The expiration time for the token.
+    /// </summary>
+    public TimeSpan TokenExpiration { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Convert the app key to a byte array.
+    /// </summary>
+    /// <returns>The app key as a byte array.</returns>
+    public byte[] ConvertAppKeyToByteArray()
+    {
+        Match match = AppKeyRegex().Match(AppleAppKey);
+
+        if (!match.Success)
+        {
+            throw new InvalidOperationException("Error parsing app key.");
+        }
+
+        string[] appKey = match
+            .Groups["keyValue"]
+            .Value
+            .Split("\n");
+
+        return Convert.FromBase64String(string.Join("", appKey));
+    }
+
+    [GeneratedRegex(
+        pattern: "-{5}BEGIN PRIVATE KEY-{5}\n(?'keyValue'(?s).+?)\n-{5}END PRIVATE KEY-{5}"
+    )]
+    private static partial Regex AppKeyRegex();
+}

--- a/src/Lib.Services/Services/AppleMusicApiService/IAppleMusicApiService.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/IAppleMusicApiService.cs
@@ -8,6 +8,10 @@ namespace MuzakBot.Lib.Services;
 public interface IAppleMusicApiService
 {
     Task<Artist[]> SearchArtistsAsync(string searchTerm);
+    Task<Album[]> SearchAlbumsAsync(string searchTerm);
+    Task<Song[]> SearchSongsAsync(string searchTerm);
 
     Task<Artist> GetArtistFromCatalogAsync(string id);
+    Task<Album> GetAlbumFromCatalogAsync(string id);
+    Task<Song> GetSongFromCatalogAsync(string id);
 }

--- a/src/Lib.Services/Services/AppleMusicApiService/IAppleMusicApiService.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/IAppleMusicApiService.cs
@@ -8,4 +8,6 @@ namespace MuzakBot.Lib.Services;
 public interface IAppleMusicApiService
 {
     Task<Artist[]> SearchArtistsAsync(string searchTerm);
+
+    Task<Artist> GetArtistFromCatalogAsync(string id);
 }

--- a/src/Lib.Services/Services/AppleMusicApiService/IAppleMusicApiService.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/IAppleMusicApiService.cs
@@ -1,0 +1,11 @@
+using MuzakBot.Lib.Models.AppleMusic;
+
+namespace MuzakBot.Lib.Services;
+
+/// <summary>
+/// Interface for services that interact with the Apple Music API.
+/// </summary>
+public interface IAppleMusicApiService
+{
+    Task<Artist[]> SearchArtistsAsync(string searchTerm);
+}

--- a/src/Lib/Models/AppleMusic/Album.cs
+++ b/src/Lib/Models/AppleMusic/Album.cs
@@ -1,0 +1,34 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the data for an Apple Music album.
+/// </summary>
+public sealed class Album : IAlbum
+{
+    /// <summary>
+    /// The identifier for the album.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
+
+    /// <summary>
+    /// The type of the item.
+    /// </summary>
+    /// <remarks>
+    /// This value will always be "albums".
+    /// </remarks>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
+
+    /// <summary>
+    /// The relative location for the album resource.
+    /// </summary>
+    [JsonPropertyName("href")]
+    public string Href { get; set; } = null!;
+
+    /// <summary>
+    /// The attributes for the album.
+    /// </summary>
+    [JsonPropertyName("attributes")]
+    public AlbumAttributes? Attributes { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/AlbumAttributes.cs
+++ b/src/Lib/Models/AppleMusic/AlbumAttributes.cs
@@ -1,0 +1,97 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the attributes data for an Apple Music album.
+/// </summary>
+public sealed class AlbumAttributes : IAlbumAttributes
+{
+    /// <summary>
+    /// The name of the artist for the album.
+    /// </summary>
+    [JsonPropertyName("artistName")]
+    public string ArtistName { get; set; } = null!;
+
+    /// <summary>
+    /// The album artwork.
+    /// </summary>
+    [JsonPropertyName("artwork")]
+    public Artwork Artwork { get; set; } = null!;
+
+    /// <summary>
+    /// The content rating for the album.
+    /// </summary>
+    [JsonPropertyName("contentRating")]
+    public string? ContentRating { get; set; }
+
+    /// <summary>
+    /// The copyright text.
+    /// </summary>
+    [JsonPropertyName("copyright")]
+    public string? Copyright { get; set; }
+
+    /// <summary>
+    /// The names of the genres associated with this album.
+    /// </summary>
+    [JsonPropertyName("genreNames")]
+    public string[] GenreNames { get; set; } = null!;
+
+    /// <summary>
+    /// Indicates whether the album is marked as a compilation.
+    /// </summary>
+    [JsonPropertyName("isCompilation")]
+    public bool IsCompilation { get; set; }
+
+    /// <summary>
+    /// Indicates whether the album is complete.
+    /// </summary>
+    [JsonPropertyName("isComplete")]
+    public bool IsComplete { get; set; }
+
+    /// <summary>
+    /// Indicates whether the album is "Mastered for iTunes".
+    /// </summary>
+    [JsonPropertyName("isMasteredForItunes")]
+    public bool IsMasteredForItunes { get; set; }
+
+    /// <summary>
+    /// Indicates whether the album is for a single.
+    /// </summary>
+    [JsonPropertyName("isSingle")]
+    public bool IsSingle { get; set; }
+
+    /// <summary>
+    /// The name of the album.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// The record label for the album.
+    /// </summary>
+    [JsonPropertyName("recordLabel")]
+    public string? RecordLabel { get; set; }
+
+    /// <summary>
+    /// The release date of the album.
+    /// </summary>
+    [JsonPropertyName("releaseDate")]
+    public DateOnly ReleaseDate { get; set; }
+
+    /// <summary>
+    /// The number of tracks on the album.
+    /// </summary>
+    [JsonPropertyName("trackCount")]
+    public int TrackCount { get; set; }
+
+    /// <summary>
+    /// The Universal Product Code (UPC) for the album.
+    /// </summary>
+    [JsonPropertyName("upc")]
+    public string? Upc { get; set; }
+
+    /// <summary>
+    /// The URL for sharing the album on Apple Music.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = null!;
+}

--- a/src/Lib/Models/AppleMusic/AppleMusicResponse.cs
+++ b/src/Lib/Models/AppleMusic/AppleMusicResponse.cs
@@ -1,0 +1,14 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// The response to an Apple Music API request.
+/// </summary>
+/// <typeparam name="T">The type of data returned by the request.</typeparam>
+public class AppleMusicResponse<T>
+{
+    /// <summary>
+    /// The data returned by the request.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public T[]? Data { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/Artist.cs
+++ b/src/Lib/Models/AppleMusic/Artist.cs
@@ -1,0 +1,34 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds data for an Apple Music artist.
+/// </summary>
+public sealed class Artist : IArtist
+{
+    /// <summary>
+    /// The identifier for the artist.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
+
+    /// <summary>
+    /// The type of the item.
+    /// </summary>
+    /// <remarks>
+    /// This value will always be "artists".
+    /// </remarks>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
+
+    /// <summary>
+    /// The relative location for the artist resource.
+    /// </summary>
+    [JsonPropertyName("href")]
+    public string Href { get; set; } = null!;
+
+    /// <summary>
+    /// The attributes for the artist.
+    /// </summary>
+    [JsonPropertyName("attributes")]
+    public ArtistAttributes? Attributes { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/ArtistAtrributes.cs
+++ b/src/Lib/Models/AppleMusic/ArtistAtrributes.cs
@@ -1,0 +1,31 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the attributes data for an Apple Music artist.
+/// </summary>
+public sealed class ArtistAttributes : IArtistAttributes
+{
+    /// <summary>
+    /// The artwork for the artist.
+    /// </summary>
+    [JsonPropertyName("artwork")]
+    public Artwork? Artwork { get; set; }
+
+    /// <summary>
+    /// The names of the genres associated with this artist.
+    /// </summary>
+    [JsonPropertyName("genreNames")]
+    public string[] GenreNames { get; set; } = null!;
+
+    /// <summary>
+    /// The name of the artist.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// The URL for sharing the artist in Apple Music.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = null!;
+}

--- a/src/Lib/Models/AppleMusic/Artwork.cs
+++ b/src/Lib/Models/AppleMusic/Artwork.cs
@@ -1,0 +1,55 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds data about the artwork for an Apple Music item.
+/// </summary>
+public sealed class Artwork : IArtwork
+{
+    /// <summary>
+    /// The average background color of the image.
+    /// </summary>
+    [JsonPropertyName("bgColor")]
+    public string? BackgroundColor { get; set; }
+
+    /// <summary>
+    /// The maximum height of the image.
+    /// </summary>
+    [JsonPropertyName("height")]
+    public int Height { get; set; }
+
+    /// <summary>
+    /// The maximum width of the image.
+    /// </summary>
+    [JsonPropertyName("width")]
+    public int Width { get; set; }
+
+    /// <summary>
+    /// The primary text color used if the background color gets displayed.
+    /// </summary>
+    [JsonPropertyName("textColor1")]
+    public string? TextColor1 { get; set; }
+
+    /// <summary>
+    /// The secondary text color used if the background color gets displayed.
+    /// </summary>
+    [JsonPropertyName("textColor2")]
+    public string? TextColor2 { get; set; }
+
+    /// <summary>
+    /// The tertiary text color used if the background color gets displayed.
+    /// </summary>
+    [JsonPropertyName("textColor3")]
+    public string? TextColor3 { get; set; }
+
+    /// <summary>
+    /// The final post-tertiary text color used if the background color gets displayed.
+    /// </summary>
+    [JsonPropertyName("textColor4")]
+    public string? TextColor4 { get; set; }
+
+    /// <summary>
+    /// The URL to request the image asset.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = null!;
+}

--- a/src/Lib/Models/AppleMusic/CatalogItemType.cs
+++ b/src/Lib/Models/AppleMusic/CatalogItemType.cs
@@ -1,0 +1,8 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+public enum CatalogItemType
+{
+    Artists = 0,
+    Albums = 1,
+    Songs = 2
+}

--- a/src/Lib/Models/AppleMusic/CatalogRequest.cs
+++ b/src/Lib/Models/AppleMusic/CatalogRequest.cs
@@ -1,0 +1,85 @@
+using System.Text;
+
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Data for constructing a catalog request to the Apple Music API.
+/// </summary>
+public sealed class CatalogRequest : IAppleMusicRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatalogRequest"/> class.
+    /// </summary>
+    /// <param name="storefront">The Apple Music storefront to search in.</param>
+    /// <param name="id">The ID of the catalog item.</param>
+    /// <param name="itemType">The type of catalog item.</param>
+    public CatalogRequest(string storefront, string id, CatalogItemType itemType)
+    {
+        Storefront = storefront;
+        Id = id;
+        ItemType = itemType;
+        _itemTypeString = CatalogItemTypeToString(itemType);
+    }
+
+    /// <summary>
+    /// The Apple Music storefront to search in.
+    /// </summary>
+    /// <remarks>
+    /// This is specified by an ISO 3166 alpha-2 country code.
+    /// </remarks>
+    public string Storefront { get; set; } = null!;
+
+    /// <summary>
+    /// The ID of the catalog item.
+    /// </summary>
+    public string Id { get; set; } = null!;
+
+    /// <summary>
+    /// The type of catalog item.
+    /// </summary>
+    public CatalogItemType ItemType { get; set; }
+
+    /// <summary>
+    /// The localization tag for the request.
+    /// </summary>
+    public string? Localization { get; set; }
+
+    /// <summary>
+    /// The <see cref="ItemType"/> as a string.
+    /// </summary>
+    private readonly string _itemTypeString;
+
+    /// <summary>
+    /// Create a URL path for the catalog request.
+    /// </summary>
+    /// <returns>A string representing the URL path.</returns>
+    public string CreateUrlPath()
+    {
+        StringBuilder urlPathBuilder = new($"v1/catalog/{Storefront}/{_itemTypeString}/{Id}");
+
+        // Add the localization to the query string if it is not null.
+        if (Localization != null && !string.IsNullOrEmpty(Localization))
+        {
+            urlPathBuilder.Append($"?l={Localization}");
+        }
+
+        return urlPathBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Converts a <see cref="CatalogItemType"/> to a string.
+    /// </summary>
+    /// <param name="itemType">The catalog item type.</param>
+    /// <returns>The catalog item type as a string.</returns>
+    /// <exception cref="ArgumentException">Thrown when the catalog item type is invalid.</exception>
+    private static string CatalogItemTypeToString(CatalogItemType itemType)
+    {
+        return itemType switch
+        {
+            CatalogItemType.Albums => "albums",
+            CatalogItemType.Artists => "artists",
+            CatalogItemType.Songs => "songs",
+            _ => throw new ArgumentException("Invalid catalog item type.", nameof(itemType))
+        };
+    }
+}

--- a/src/Lib/Models/AppleMusic/SearchRequest.cs
+++ b/src/Lib/Models/AppleMusic/SearchRequest.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using System.Web;
+
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Data for constructing a search request to the Apple Music API.
+/// </summary>
+public sealed class SearchRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchRequest"/> class.
+    /// </summary>
+    /// <param name="storefront">The Apple Music storefront to search in.</param>
+    /// <param name="term">The search term.</param>
+    /// <param name="searchTypes">The types of resources to search for.</param>
+    public SearchRequest(string storefront, string term, SearchType[] searchTypes)
+    {
+        Storefront = storefront;
+        Term = term;
+        Types = searchTypes;
+        _searchTypesStrings = SearchTypesToString(searchTypes);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchRequest"/> class.
+    /// </summary>
+    /// <param name="storefront">The Apple Music storefront to search in.</param>
+    /// <param name="term">The search term.</param>
+    /// <param name="searchTypes">The types of resources to search for.</param>
+    /// <param name="limit">The number of resources to return.</param>
+    /// <exception cref="ArgumentException">Thrown when the limit is not between 1 and 25.</exception>
+    public SearchRequest(string storefront, string term, SearchType[] searchTypes, int limit) : this(storefront, term, searchTypes)
+    {
+        if (limit < 1 || limit > 25)
+        {
+            throw new ArgumentException("Limit must be between 1 and 25.", nameof(limit));
+        }
+
+        Limit = limit;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchRequest"/> class.
+    /// </summary>
+    /// <param name="storefront">The Apple Music storefront to search in.</param>
+    /// <param name="term">The search term.</param>
+    /// <param name="searchTypes">The types of resources to search for.</param>
+    /// <param name="limit">The number of resources to return.</param>
+    /// <param name="offset">The next page of resources.</param>
+    public SearchRequest(string storefront, string term, SearchType[] searchTypes, int limit, string? offset) : this(storefront, term, searchTypes, limit)
+    {
+        Offset = offset;
+    }
+
+    /// <summary>
+    /// The Apple Music storefront to search in.
+    /// </summary>
+    /// <remarks>
+    /// This is specified by an ISO 3166 alpha-2 country code.
+    /// </remarks>
+    public string Storefront { get; set; } = null!;
+
+    /// <summary>
+    /// The search term.
+    /// </summary>
+    public string Term { get; set; } = null!;
+
+    /// <summary>
+    /// The localization tag for the request.
+    /// </summary>
+    public string? Localization { get; set; }
+
+    /// <summary>
+    /// The number of resources to return.
+    /// </summary>
+    /// <remarks>
+    /// The maximum value is 25.
+    /// </remarks>
+    public int Limit { get; set; } = 5;
+
+    /// <summary>
+    /// The next page of resources.
+    /// </summary>
+    public string? Offset { get; set; }
+
+    /// <summary>
+    /// The types of resources to search for.
+    /// </summary>
+    public SearchType[] Types { get; set; } = null!;
+
+    /// <summary>
+    /// Extra modifications for the request.
+    /// </summary>
+    public string[]? With { get; set; }
+
+    /// <summary>
+    /// The <see cref="Types"/> values as strings.
+    /// </summary>
+    private readonly string[] _searchTypesStrings;
+
+    /// <summary>
+    /// Create a URL path for the search request.
+    /// </summary>
+    /// <returns>A string representing the URL path.</returns>
+    public string CreateUrlPath()
+    {
+        StringBuilder urlPathBuilder = new($"v1/catalog/{Storefront}/search");
+
+        // Add the search types to the query string.
+        urlPathBuilder.Append($"?types={string.Join(",", _searchTypesStrings)}");
+
+        // Encode the search term and add it to the query string.
+        string encodedTermString = HttpUtility.UrlEncode(Term);
+        urlPathBuilder.Append($"&term={encodedTermString}");
+
+        // Add the limit to the query string.
+        urlPathBuilder.Append($"&limit={Limit}");
+
+        // Add the offset to the query string if it is not null.
+        if (Offset != null && !string.IsNullOrEmpty(Offset))
+        {
+            urlPathBuilder.Append($"&offset={Offset}");
+        }
+
+        // Add the localization to the query string if it is not null.
+        if (Localization != null && !string.IsNullOrEmpty(Localization))
+        {
+            urlPathBuilder.Append($"&l={Localization}");
+        }
+
+        // Add the with modifications to the query string if it is not null.
+        if (With != null && With.Length > 0)
+        {
+            urlPathBuilder.Append($"&with={string.Join(",", With)}");
+        }
+
+        return urlPathBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Convert an array of <see cref="SearchType"/> to an array of strings.
+    /// </summary>
+    /// <param name="searchTypes">The array of <see cref="SearchType"/> to convert.</param>
+    /// <returns>An array of strings representing the search types.</returns>
+    /// <exception cref="ArgumentException">Thrown when an invalid search type is encountered.</exception>
+    private static string[] SearchTypesToString(SearchType[] searchTypes)
+    {
+        string[] searchTypesStrings = new string[searchTypes.Length];
+
+        for (int i = 0; i < searchTypes.Length; i++)
+        {
+            searchTypesStrings[i] = searchTypes[i] switch
+            {
+                SearchType.Activities => "activities",
+                SearchType.Albums => "albums",
+                SearchType.AppleCurators => "apple-curators",
+                SearchType.Artists => "artists",
+                SearchType.Curators => "curators",
+                SearchType.MusicVideos => "music-videos",
+                SearchType.Playlists => "playlists",
+                SearchType.RecordLabels => "record-labels",
+                SearchType.Songs => "songs",
+                SearchType.Stations => "stations",
+                _ => throw new ArgumentException("Invalid search type.")
+            };
+        }
+
+        return searchTypesStrings;
+    }
+}

--- a/src/Lib/Models/AppleMusic/SearchRequest.cs
+++ b/src/Lib/Models/AppleMusic/SearchRequest.cs
@@ -6,7 +6,7 @@ namespace MuzakBot.Lib.Models.AppleMusic;
 /// <summary>
 /// Data for constructing a search request to the Apple Music API.
 /// </summary>
-public sealed class SearchRequest
+public sealed class SearchRequest : IAppleMusicRequest
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchRequest"/> class.

--- a/src/Lib/Models/AppleMusic/SearchResponse.cs
+++ b/src/Lib/Models/AppleMusic/SearchResponse.cs
@@ -3,12 +3,11 @@ namespace MuzakBot.Lib.Models.AppleMusic;
 /// <summary>
 /// Holds the results data for an Apple Music search request.
 /// </summary>
-/// <typeparam name="T">The type of data returned by the request.</typeparam>
-public sealed class SearchResponse<T>
+public sealed class SearchResponse
 {
     /// <summary>
     /// The results of the search request.
     /// </summary>
     [JsonPropertyName("results")]
-    public SearchResponseResults<T> Results { get; set; } = null!;
+    public SearchResponseResults Results { get; set; } = null!;
 }

--- a/src/Lib/Models/AppleMusic/SearchResponse.cs
+++ b/src/Lib/Models/AppleMusic/SearchResponse.cs
@@ -1,0 +1,14 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the results data for an Apple Music search request.
+/// </summary>
+/// <typeparam name="T">The type of data returned by the request.</typeparam>
+public sealed class SearchResponse<T>
+{
+    /// <summary>
+    /// The results of the search request.
+    /// </summary>
+    [JsonPropertyName("results")]
+    public SearchResponseResults<T> Results { get; set; } = null!;
+}

--- a/src/Lib/Models/AppleMusic/SearchResponseResults.cs
+++ b/src/Lib/Models/AppleMusic/SearchResponseResults.cs
@@ -1,26 +1,13 @@
 namespace MuzakBot.Lib.Models.AppleMusic;
 
-/// <summary>
-/// Holds the results data for an Apple Music search request.
-/// </summary>
-/// <typeparam name="T">The type of data returned by the request.</typeparam>
-public class SearchResponseResults<T>
+public sealed class SearchResponseResults
 {
-    /// <summary>
-    /// Data returned by the request.
-    /// </summary>
-    [JsonPropertyName("data")]
-    public T[] Data { get; set; } = null!;
+    [JsonPropertyName("albums")]
+    public SearchResponseResultsData<Album>? Albums { get; set; }
 
-    /// <summary>
-    /// The relative location to fetch the search result.
-    /// </summary>
-    [JsonPropertyName("href")]
-    public string? Href { get; set; }
+    [JsonPropertyName("artists")]
+    public SearchResponseResultsData<Artist>? Artists { get; set; }
 
-    /// <summary>
-    /// A relative cursor to fetch the next paginated collection of resources in the result, if more exist.
-    /// </summary>
-    [JsonPropertyName("next")]
-    public string? Next { get; set; }
+    [JsonPropertyName("songs")]
+    public SearchResponseResultsData<Song>? Songs { get; set; }
 }

--- a/src/Lib/Models/AppleMusic/SearchResponseResults.cs
+++ b/src/Lib/Models/AppleMusic/SearchResponseResults.cs
@@ -1,0 +1,26 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the results data for an Apple Music search request.
+/// </summary>
+/// <typeparam name="T">The type of data returned by the request.</typeparam>
+public class SearchResponseResults<T>
+{
+    /// <summary>
+    /// Data returned by the request.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public T[] Data { get; set; } = null!;
+
+    /// <summary>
+    /// The relative location to fetch the search result.
+    /// </summary>
+    [JsonPropertyName("href")]
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// A relative cursor to fetch the next paginated collection of resources in the result, if more exist.
+    /// </summary>
+    [JsonPropertyName("next")]
+    public string? Next { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/SearchResponseResultsData.cs
+++ b/src/Lib/Models/AppleMusic/SearchResponseResultsData.cs
@@ -1,0 +1,26 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the results data for an Apple Music search request.
+/// </summary>
+/// <typeparam name="T">The type of data returned by the request.</typeparam>
+public class SearchResponseResultsData<T>
+{
+    /// <summary>
+    /// Data returned by the request.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public T[] Data { get; set; } = null!;
+
+    /// <summary>
+    /// The relative location to fetch the search result.
+    /// </summary>
+    [JsonPropertyName("href")]
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// A relative cursor to fetch the next paginated collection of resources in the result, if more exist.
+    /// </summary>
+    [JsonPropertyName("next")]
+    public string? Next { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/SearchType.cs
+++ b/src/Lib/Models/AppleMusic/SearchType.cs
@@ -1,0 +1,18 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// The types of resources to search for.
+/// </summary>
+public enum SearchType
+{
+    Activities = 0,
+    Albums = 1,
+    AppleCurators = 2,
+    Artists = 3,
+    Curators = 4,
+    MusicVideos = 5,
+    Playlists = 6,
+    RecordLabels = 7,
+    Songs = 8,
+    Stations = 9
+}

--- a/src/Lib/Models/AppleMusic/Song.cs
+++ b/src/Lib/Models/AppleMusic/Song.cs
@@ -1,0 +1,34 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds data about a song from Apple Music.
+/// </summary>
+public sealed class Song : ISong
+{
+    /// <summary>
+    /// The identifier for the song.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
+
+    /// <summary>
+    /// The type of the resource.
+    /// </summary>
+    /// <remarks>
+    /// This will always be "songs".
+    /// </remarks>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
+
+    /// <summary>
+    /// The relative location for the song resource.
+    /// </summary>
+    [JsonPropertyName("href")]
+    public string Href { get; set; } = null!;
+
+    /// <summary>
+    /// The attributes for the song.
+    /// </summary>
+    [JsonPropertyName("attributes")]
+    public SongAttributes? Attributes { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/SongAttributes.cs
+++ b/src/Lib/Models/AppleMusic/SongAttributes.cs
@@ -1,0 +1,97 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Holds the attributes data for a song from Apple Music.
+/// </summary>
+public sealed class SongAttributes : ISongAttributes
+{
+    /// <summary>
+    /// The name of the album that the song is from.
+    /// </summary>
+    [JsonPropertyName("albumName")]
+    public string AlbumName { get; set; } = null!;
+
+    /// <summary>
+    /// The name of the artist that made the song.
+    /// </summary>
+    [JsonPropertyName("artistName")]
+    public string ArtistName { get; set; } = null!;
+
+    /// <summary>
+    /// The URL for the artist that made the song.
+    /// </summary>
+    [JsonPropertyName("artistUrl")]
+    public string ArtistUrl { get; set; } = null!;
+
+    /// <summary>
+    /// The artwork for the song.
+    /// </summary>
+    [JsonPropertyName("artwork")]
+    public Artwork Artwork { get; set; } = null!;
+
+    /// <summary>
+    /// The name of the composer for the song.
+    /// </summary>
+    [JsonPropertyName("composerName")]
+    public string? ComposerName { get; set; }
+
+    /// <summary>
+    /// The content rating for the song.
+    /// </summary>
+    [JsonPropertyName("contentRating")]
+    public string? ContentRating { get; set; }
+
+    /// <summary>
+    /// The disc number for the song.
+    /// </summary>
+    [JsonPropertyName("discNumber")]
+    public int DiscNumber { get; set; }
+
+    /// <summary>
+    /// The duration of the song in milliseconds.
+    /// </summary>
+    [JsonPropertyName("durationInMillis")]
+    public int DurationInMillis { get; set; }
+
+    /// <summary>
+    /// The genre names the song is associated with.
+    /// </summary>
+    [JsonPropertyName("genreNames")]
+    public string[] GenreNames { get; set; } = null!;
+
+    /// <summary>
+    /// Indicates whether the song has lyrics.
+    /// </summary>
+    [JsonPropertyName("hasLyrics")]
+    public bool HasLyrics { get; set; }
+
+    /// <summary>
+    /// The International Standard Recording Code (ISRC) for the song.
+    /// </summary>
+    [JsonPropertyName("isrc")]
+    public string? Isrc { get; set; }
+
+    /// <summary>
+    /// The name of the song.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// The release date of the song.
+    /// </summary>
+    [JsonPropertyName("releaseDate")]
+    public DateOnly ReleaseDate { get; set; }
+
+    /// <summary>
+    /// The track number for the song.
+    /// </summary>
+    [JsonPropertyName("trackNumber")]
+    public int TrackNumber { get; set; }
+
+    /// <summary>
+    /// The URL for sharing the song in Apple Music.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = null!;
+}

--- a/src/Lib/Models/AppleMusic/interfaces/IAlbum.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/IAlbum.cs
@@ -1,0 +1,12 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music album.
+/// </summary>
+public interface IAlbum
+{
+    string Id { get; set; }
+    string Type { get; set; }
+    string Href { get; set; }
+    AlbumAttributes? Attributes { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/interfaces/IAlbumAttributes.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/IAlbumAttributes.cs
@@ -1,0 +1,23 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music album's attributes.
+/// </summary>
+public interface IAlbumAttributes
+{
+    string ArtistName { get; set; }
+    Artwork Artwork { get; set; }
+    string? ContentRating { get; set; }
+    string? Copyright { get; set; }
+    string[] GenreNames { get; set; }
+    bool IsCompilation { get; set; }
+    bool IsComplete { get; set; }
+    bool IsMasteredForItunes { get; set; }
+    bool IsSingle { get; set; }
+    string Name { get; set; }
+    string? RecordLabel { get; set; }
+    DateOnly ReleaseDate { get; set; }
+    int TrackCount { get; set; }
+    string? Upc { get; set; }
+    string Url { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/interfaces/IAppleMusicRequest.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/IAppleMusicRequest.cs
@@ -1,0 +1,6 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+public interface IAppleMusicRequest
+{
+    string CreateUrlPath();
+}

--- a/src/Lib/Models/AppleMusic/interfaces/IArtist.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/IArtist.cs
@@ -1,0 +1,12 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music artist.
+/// </summary>
+public interface IArtist
+{
+    string Id { get; set; }
+    string Type { get; set; }
+    string Href { get; set; }
+    ArtistAttributes? Attributes { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/interfaces/IArtistAttributes.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/IArtistAttributes.cs
@@ -1,0 +1,12 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music artist.
+/// </summary>
+public interface IArtistAttributes
+{
+    Artwork? Artwork { get; set; }
+    string[] GenreNames { get; set; }
+    string Name { get; set; }
+    string Url { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/interfaces/IArtwork.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/IArtwork.cs
@@ -1,0 +1,16 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music artwork.
+/// </summary>
+public interface IArtwork
+{
+    string? BackgroundColor { get; set; }
+    int Height { get; set; }
+    int Width { get; set; }
+    string? TextColor1 { get; set; }
+    string? TextColor2 { get; set; }
+    string? TextColor3 { get; set; }
+    string? TextColor4 { get; set; }
+    string Url { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/interfaces/ISong.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/ISong.cs
@@ -1,0 +1,12 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music song.
+/// </summary>
+public interface ISong
+{
+    string Id { get; set; }
+    string Type { get; set; }
+    string Href { get; set; }
+    SongAttributes? Attributes { get; set; }
+}

--- a/src/Lib/Models/AppleMusic/interfaces/ISongAttributes.cs
+++ b/src/Lib/Models/AppleMusic/interfaces/ISongAttributes.cs
@@ -1,0 +1,23 @@
+namespace MuzakBot.Lib.Models.AppleMusic;
+
+/// <summary>
+/// Interface for an Apple Music song's attributes.
+/// </summary>
+public interface ISongAttributes
+{
+    string AlbumName { get; set; }
+    string ArtistName { get; set; }
+    string ArtistUrl { get; set; }
+    Artwork Artwork { get; set; }
+    string? ComposerName { get; set; }
+    string? ContentRating { get; set; }
+    int DiscNumber { get; set; }
+    int DurationInMillis { get; set; }
+    string[] GenreNames { get; set; }
+    bool HasLyrics { get; set; }
+    string? Isrc { get; set; }
+    string Name { get; set; }
+    DateOnly ReleaseDate { get; set; }
+    int TrackNumber { get; set; }
+    string Url { get; set; }
+}


### PR DESCRIPTION
## Description

This PR adds the Apple Music API as a source for looking up songs, albums, and artists. This also means that all autocomplete results will be coming from the Apple Music API and not the MusicBrainz API from now on.

In addition, this change _should_ help with reducing the number of unrelated autocomplete entries.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
