### PR TITLE
Disable self-contained deployment and trimming for GeniusService

### DIFF
--- a/Dockerfile.MuzakBot
+++ b/Dockerfile.MuzakBot
@@ -19,7 +19,7 @@ RUN dotnet publish ./src/App --configuration "Release" --os "${TARGETOS}" --arch
 RUN rm -rf /app/artifacts/publish/App/release/*.pdb; \
     rm -rf /app/artifacts/publish/App/release/*.dbg
 
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/runtime:8.0
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/src/GeniusService/GeniusService.csproj
+++ b/src/GeniusService/GeniusService.csproj
@@ -9,9 +9,9 @@
 		<Nullable>enable</Nullable>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 		<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-		<PublishSingleFile>true</PublishSingleFile>
-		<SelfContained>true</SelfContained>
-		<PublishTrimmed>true</PublishTrimmed>
+		<PublishSingleFile>false</PublishSingleFile>
+		<SelfContained>false</SelfContained>
+		<PublishTrimmed>false</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
 		<CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
 	</PropertyGroup>


### PR DESCRIPTION
## Description

This PR is disabling the self-contained deployment and trimming options for `GeniusService`. As it stands right now, with EFCore and it's CosmosDB provider, I can't fully guarantee that trimming is 100% not breaking anything. I'm going to err on the side of caution for now.

Good news is that it makes the container image smaller.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
