### PR TITLE
Make the output for "Get music share links" ephemeral

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/commands/HandleGetLinksFromPostAsync.cs
@@ -30,7 +30,9 @@ public partial class ShareMusicCommandModule
         {
             Regex linkRegex = new(@"(?'musicLink'(?>https|http):\/\/(?>[A-Za-z0-9\.]+)(?>\/\S*[^\.\s]|))(?> |)", RegexOptions.Multiline);
 
-            await DeferAsync();
+            await DeferAsync(
+                ephemeral: true
+            );
 
             _logger.LogInformation("Message content: {messageContent}", message.CleanContent);
 
@@ -147,7 +149,8 @@ public partial class ShareMusicCommandModule
                 embed: messageEmbed.Build(),
                 fileStream: albumArtStream,
                 fileName: $"{streamingEntityItem.Id}.jpg",
-                components: linksComponentBuilder.Build()
+                components: linksComponentBuilder.Build(),
+                ephemeral: true
             );
 
             albumArtStream.Dispose();


### PR DESCRIPTION
## Description

This PR makes the message command "Get music share links" always output as ephemeral. I think this would be very beneficial for not annoying other people. Especially when you use it in a server without MuzakBot and with fewer than 25 users. No one's complained about it, but it seems smarter to do that.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
