### PR TITLE
Change model to gpt-4-turbo

### DIFF
--- a/src/Lib.Services/Services/OpenAiService/OpenAiService.cs
+++ b/src/Lib.Services/Services/OpenAiService/OpenAiService.cs
@@ -69,7 +69,7 @@ public partial class OpenAiService : IOpenAiService
 
         OpenAiChatCompletionRequest request = new()
         {
-            Model = "gpt-4-turbo-preview",
+            Model = "gpt-4-turbo",
             Temperature = 1,
             MaxTokens = 512,
             TopP = 1,


### PR DESCRIPTION
## Description

This PR changes the OpenAI GPT-4 model from `gpt-4-turbo-preview` to `gpt-4-turbo`.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
