### PR TITLE
Fix the PlatformEntityLink always being YouTube

### DIFF
--- a/src/App/Models/Responses/ShareMusicResponse.cs
+++ b/src/App/Models/Responses/ShareMusicResponse.cs
@@ -225,7 +225,7 @@ public class ShareMusicResponse : IResponse
         PlatformEntityLink? platformEntityLink = null;
         try
         {
-            platformEntityLink = entityItem.LinksByPlatform!["youtube"];
+            platformEntityLink = entityItem.LinksByPlatform![platform];
         }
         catch
         {


### PR DESCRIPTION
## Description

This PR fixes a bug where streaming service links always resolved to YouTube links. 😬

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
