### PR TITLE
Group the share music slash commands

### DIFF
--- a/src/App/Modules/ShareMusicCommandModule/Commands/FindAlbumCommandAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/Commands/FindAlbumCommandAsync.cs
@@ -23,7 +23,7 @@ public partial class ShareMusicCommandModule
     [IntegrationType(ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall)]
     [SlashCommand(
         name: "findalbum",
-        description: "Find an album from an artist"
+        description: "Get share links by searching for an album by an artist."
     )]
     private async Task FindAlbumCommandAsync(
         [Summary("artistName", "The name of an artist"),

--- a/src/App/Modules/ShareMusicCommandModule/Commands/FindSongCommandAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/Commands/FindSongCommandAsync.cs
@@ -20,7 +20,7 @@ public partial class ShareMusicCommandModule
     [IntegrationType(ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall)]
     [SlashCommand(
         name: "findsong",
-        description: "Find music from an artist"
+        description: "Get share links by searching for a song by an artist."
     )]
     private async Task FindSongCommandAsync(
         [Summary("artistName", "The name of an artist"),

--- a/src/App/Modules/ShareMusicCommandModule/Commands/ShareMusicCommandAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/Commands/ShareMusicCommandAsync.cs
@@ -19,8 +19,8 @@ public partial class ShareMusicCommandModule
     [CommandContextType(InteractionContextType.BotDm, InteractionContextType.PrivateChannel, InteractionContextType.Guild)]
     [IntegrationType(ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall)]
     [SlashCommand(
-        name: "sharemusic",
-        description: "Get share links to a song or album on various streaming platforms."
+        name: "url",
+        description: "Get share links from a streaming service URL."
     )]
     private async Task ShareMusicCommandAsync(
         [Summary(

--- a/src/App/Modules/ShareMusicCommandModule/ComponentInteractions/HandleMusicShareMessageRemovalAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/ComponentInteractions/HandleMusicShareMessageRemovalAsync.cs
@@ -18,7 +18,7 @@ public partial class ShareMusicCommandModule
     /// invoked by a user clicking the "Remove message" button on
     /// a failed share message.
     /// </remarks>
-    [ComponentInteraction(customId: "remove-sharemusic-post-btn-*")]
+    [ComponentInteraction(customId: "remove-sharemusic-post-btn-*", true)]
     private async Task HandleMusicShareMessageRemovalAsync()
     {
         using var activity = _activitySource.StartHandleMusicShareMessageRemovalAsyncActivity(Context);

--- a/src/App/Modules/ShareMusicCommandModule/ComponentInteractions/HandleMusicShareRefreshAsync.cs
+++ b/src/App/Modules/ShareMusicCommandModule/ComponentInteractions/HandleMusicShareRefreshAsync.cs
@@ -19,7 +19,7 @@ public partial class ShareMusicCommandModule
     /// existing message.
     /// </remarks>
     /// <param name="url">The Songlink/Odesli URL.</param>
-    [ComponentInteraction(customId: "refresh-musiclinks-btn-*")]
+    [ComponentInteraction(customId: "refresh-musiclinks-btn-*", true)]
     private async Task HandleMusicShareRefreshAsync(string url)
     {
         using var activity = _activitySource.StartHandleMusicShareRefreshAsyncActivity(url, Context);

--- a/src/App/Modules/ShareMusicCommandModule/ShareMusicCommandModule.cs
+++ b/src/App/Modules/ShareMusicCommandModule/ShareMusicCommandModule.cs
@@ -13,6 +13,7 @@ namespace MuzakBot.App.Modules;
 /// </summary>
 [CommandContextType(InteractionContextType.BotDm, InteractionContextType.PrivateChannel, InteractionContextType.Guild)]
 [IntegrationType(ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall)]
+[Group("sharemusic", "Create share links for a song or album on various streaming platforms.")]
 public partial class ShareMusicCommandModule : InteractionModuleBase<SocketInteractionContext>, IDisposable
 {
     private bool _isDisposed;


### PR DESCRIPTION
## Description

This PR changes how the slash commands in the `ShareMusicCommandModule` are defined. The commands are now grouped together to make it easier to identify what they are used for.

* `/sharemusic` -> `/sharemusic url`
* `/findsong` -> `/sharemusic findsong`
* `/findalbum` -> `/sharemusic findalbum`

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
