### PR TITLE
Add precondition attributes for lyrics analyzer commands

### DIFF
--- a/src/App/Preconditions/LyricsAnalyzer/RequireLyricsAnalyzerEnabledForServerAttribute.cs
+++ b/src/App/Preconditions/LyricsAnalyzer/RequireLyricsAnalyzerEnabledForServerAttribute.cs
@@ -1,0 +1,79 @@
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.Database;
+using MuzakBot.Lib.Models.Database.LyricsAnalyzer;
+
+namespace MuzakBot.App.Preconditions.LyricsAnalyzer;
+
+/// <summary>
+/// Precondition attribute to check if the '/lyricsanalyzer' command is enabled for the current server.
+/// </summary>
+public class RequireLyricsAnalyzerEnabledForServerAttribute : PreconditionAttribute
+{
+    /// <inheritdoc />
+    public override async Task<PreconditionResult> CheckRequirementsAsync(IInteractionContext context, ICommandInfo commandInfo, IServiceProvider services)
+    {
+        var lyricsAnalyzerDbContextFactory = services.GetRequiredService<IDbContextFactory<LyricsAnalyzerDbContext>>();
+        var logger = services.GetRequiredService<ILogger<RequireLyricsAnalyzerEnabledForServerAttribute>>();
+
+        using var dbContext = lyricsAnalyzerDbContextFactory.CreateDbContext();
+
+        LyricsAnalyzerConfig lyricsAnalyzerConfig;
+        try
+        {
+            lyricsAnalyzerConfig = await dbContext.LyricsAnalyzerConfigs
+                .WithPartitionKey("lyricsanalyzer-config")
+                .FirstAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting lyrics analyzer config from database.");
+
+            EmbedBuilder rateLimitExceededEmbed = new EmbedBuilder()
+                    .WithTitle("💥 An error occurred")
+                    .WithDescription("An error occurred while checking your rate limit. Please try again later. 😥")
+                    .WithColor(Color.Red);
+
+            return PreconditionResult.FromError(ex);
+        }
+
+        // Check if the command is enabled for the current server.
+        if (!context.Interaction.IsDMInteraction && lyricsAnalyzerConfig.CommandIsEnabledToSpecificGuilds && lyricsAnalyzerConfig.CommandEnabledGuildIds is not null && !lyricsAnalyzerConfig.CommandEnabledGuildIds.Contains(context.Guild.Id))
+        {
+            EmbedBuilder notEnabledEmbed = new EmbedBuilder()
+                .WithTitle("💥 An error occurred")
+                .WithDescription("This command is not enabled on this server. 😥")
+                .WithColor(Color.Red);
+
+            await context.Interaction.RespondAsync(
+                embed: notEnabledEmbed.Build(),
+                ephemeral: true
+            );
+
+            return PreconditionResult.FromError("The '/lyricsanalyzer' command is not enabled for this server.");
+        }
+
+        // Check if the command is disabled for the current server.
+        if (!context.Interaction.IsDMInteraction && !lyricsAnalyzerConfig.CommandIsEnabledToSpecificGuilds && lyricsAnalyzerConfig.CommandDisabledGuildIds is not null && lyricsAnalyzerConfig.CommandDisabledGuildIds.Contains(context.Guild.Id))
+        {
+            EmbedBuilder notEnabledEmbed = new EmbedBuilder()
+                .WithTitle("💥 An error occurred")
+                .WithDescription("This command is not enabled on this server. 😥")
+                .WithColor(Color.Red);
+
+            await context.Interaction.RespondAsync(
+                embed: notEnabledEmbed.Build(),
+                ephemeral: true
+            );
+
+            return PreconditionResult.FromError("The '/lyricsanalyzer' command is not enabled for this server.");
+        }
+
+        return PreconditionResult.FromSuccess();
+    }
+}

--- a/src/App/Preconditions/LyricsAnalyzer/RequireUserRateLimitAttribute.cs
+++ b/src/App/Preconditions/LyricsAnalyzer/RequireUserRateLimitAttribute.cs
@@ -1,0 +1,97 @@
+using System.Text;
+
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.Database;
+using MuzakBot.Lib.Models.Database.LyricsAnalyzer;
+
+namespace MuzakBot.App.Preconditions.LyricsAnalyzer;
+
+/// <summary>
+/// Precondition attribute to check if the user has reached the rate limit for the '/lyricsanalyzer' command.
+/// </summary>
+public class RequireUserRateLimitAttribute : PreconditionAttribute
+{
+    /// <inheritdoc />
+    public override async Task<PreconditionResult> CheckRequirementsAsync(IInteractionContext context, ICommandInfo commandInfo, IServiceProvider services)
+    {
+        var lyricsAnalyzerDbContextFactory = services.GetRequiredService<IDbContextFactory<LyricsAnalyzerDbContext>>();
+        var logger = services.GetRequiredService<ILogger<RequireUserRateLimitAttribute>>();
+
+        using var dbContext = lyricsAnalyzerDbContextFactory.CreateDbContext();
+
+        LyricsAnalyzerConfig lyricsAnalyzerConfig;
+        try
+        {
+            lyricsAnalyzerConfig = await dbContext.LyricsAnalyzerConfigs
+                .WithPartitionKey("lyricsanalyzer-config")
+                .FirstAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting lyrics analyzer config from database.");
+
+            EmbedBuilder rateLimitExceededEmbed = new EmbedBuilder()
+                    .WithTitle("💥 An error occurred")
+                    .WithDescription("An error occurred while checking your rate limit. Please try again later. 😥")
+                    .WithColor(Color.Red);
+
+            return PreconditionResult.FromError(ex);
+        }
+
+        // Check if the current user is on the rate limit ignore list.
+        bool userIsOnRateLimitIgnoreList = lyricsAnalyzerConfig.RateLimitIgnoredUserIds is not null && lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Contains(context.User.Id.ToString());
+
+        // Get the current rate limit for the user.
+        LyricsAnalyzerUserRateLimit? lyricsAnalyzerUserRateLimit = null;
+        if (lyricsAnalyzerConfig.RateLimitEnabled && !userIsOnRateLimitIgnoreList)
+        {
+            logger.LogInformation("Getting current rate limit for user '{UserId}' from database.", context.User.Id);
+            lyricsAnalyzerUserRateLimit = await dbContext.LyricsAnalyzerUserRateLimits
+                .WithPartitionKey("user-item")
+                .FirstOrDefaultAsync(item => item.UserId == context.User.Id.ToString());
+
+            if (lyricsAnalyzerUserRateLimit is null)
+            {
+                lyricsAnalyzerUserRateLimit = new(context.User.Id.ToString());
+
+                dbContext.LyricsAnalyzerUserRateLimits.Add(lyricsAnalyzerUserRateLimit);
+
+                await dbContext.SaveChangesAsync();
+            }
+
+            logger.LogInformation("Current rate limit for user '{UserId}' is {CurrentRequestCount}/{MaxRequests}.", context.User.Id, lyricsAnalyzerUserRateLimit.CurrentRequestCount, lyricsAnalyzerConfig.RateLimitMaxRequests);
+
+            // If the user has reached the rate limit, send a message and return.
+            if (!lyricsAnalyzerUserRateLimit.EvaluateRequest(lyricsAnalyzerConfig.RateLimitMaxRequests))
+            {
+                logger.LogInformation("User '{UserId}' has reached the rate limit.", context.User.Id);
+
+                StringBuilder rateLimitMessageBuilder = new($"You have reached the rate limit ({lyricsAnalyzerConfig.RateLimitMaxRequests} requests) for this command. 😥\n\n");
+
+                DateTimeOffset resetTime = lyricsAnalyzerUserRateLimit.LastRequestTime.AddDays(1);
+
+                rateLimitMessageBuilder.AppendLine($"Rate limit will reset <t:{resetTime.ToUnixTimeSeconds()}:R>.");
+
+                EmbedBuilder rateLimitExceededEmbed = new EmbedBuilder()
+                    .WithTitle("💥 An error occurred")
+                    .WithDescription(rateLimitMessageBuilder.ToString())
+                    .WithColor(Color.Red);
+
+                await context.Interaction.RespondAsync(
+                    embed: rateLimitExceededEmbed.Build(),
+                    ephemeral: true
+                );
+
+                return PreconditionResult.FromError("User has reached the rate limit for this command.");
+            }
+        }
+
+        return PreconditionResult.FromSuccess();
+    }
+}


### PR DESCRIPTION
## Description

This PR adds two precondition attributes for lyrics analyzer commands:

* `RequireUserRateLimitAttribute`
* `RequireLyricsAnalyzerEnabledForServerAttribute`

These replace the checks while processing the interactions to before the interaction is even ran.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
