### PR TITLE
Add '/lyricsanalyzer url' slash command

### DIFF
--- a/src/App/Extensions/LyricsAnalyzerCommandModuleActivityExtensions.cs
+++ b/src/App/Extensions/LyricsAnalyzerCommandModuleActivityExtensions.cs
@@ -41,14 +41,57 @@ internal static class LyricsAnalyzerCommandModuleActivityExtensions
                 kind: ActivityKind.Server,
                 tags: new ActivityTagsCollection
                 {
-                { "command_Type", "SlashCommand"},
-                { "command_Name", "lyricsanalyzer search" },
-                { "artist_Name", artistName },
-                { "song_Name", songName },
-                { "guild_Id", context.Guild.Id },
-                { "guild_Name", context.Guild.Name },
-                { "channel_Id", context.Channel.Id },
-                { "channel_Name", context.Channel.Name }
+                    { "command_Type", "SlashCommand"},
+                    { "command_Name", "lyricsanalyzer search" },
+                    { "artist_Name", artistName },
+                    { "song_Name", songName },
+                    { "guild_Id", context.Guild.Id },
+                    { "guild_Name", context.Guild.Name },
+                    { "channel_Id", context.Channel.Id },
+                    { "channel_Name", context.Channel.Name }
+                }
+            );
+        }
+    }
+
+    /// <summary>
+    /// Starts an activity for <see cref="Modules.LyricsAnalyzerCommandModule.LyricsAnalyzerUrlCommandAsync(string, string, bool)"/>.
+    /// </summary>
+    /// <param name="activitySource">The activity source.</param>
+    /// <param name="url">The streaming service URL.</param>
+    /// <param name="context">The <see cref="IInteractionContext"/> for the request.</param>
+    /// <returns>The started activity.</returns>
+    public static Activity? StartLyricsAnalyzerUrlCommandAsyncActivity(this ActivitySource activitySource, string url, IInteractionContext context)
+    {
+        if (context.Interaction.IsDMInteraction)
+        {
+            return activitySource.StartActivity(
+                name: "LyricsAnalyzerUrlCommandAsync",
+                kind: ActivityKind.Server,
+                tags: new ActivityTagsCollection
+                {
+                    { "command_Type", "SlashCommand"},
+                    { "command_Name", "lyricsanalyzer url" },
+                    { "url", url },
+                    { "user_Id", context.User.Id },
+                    { "isDM", true }
+                }
+            );
+        }
+        else
+        {
+            return activitySource.StartActivity(
+                name: "LyricsAnalyzerUrlCommandAsync",
+                kind: ActivityKind.Server,
+                tags: new ActivityTagsCollection
+                {
+                    { "command_Type", "SlashCommand"},
+                    { "command_Name", "lyricsanalyzer url" },
+                    { "url", url },
+                    { "guild_Id", context.Guild.Id },
+                    { "guild_Name", context.Guild.Name },
+                    { "channel_Id", context.Channel.Id },
+                    { "channel_Name", context.Channel.Name }
                 }
             );
         }

--- a/src/App/Modules/LyricsAnalyzerCommandModule/Commands/LyricsAnalyzerUrlCommandAsync.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Commands/LyricsAnalyzerUrlCommandAsync.cs
@@ -1,0 +1,357 @@
+using System.Diagnostics;
+using System.Text;
+
+using Discord;
+using Discord.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+using MuzakBot.App.Extensions;
+using MuzakBot.App.Handlers;
+using MuzakBot.App.Models.Responses;
+using MuzakBot.App.Preconditions.LyricsAnalyzer;
+using MuzakBot.App.Services;
+using MuzakBot.Lib;
+using MuzakBot.Lib.Models.AppleMusic;
+using MuzakBot.Lib.Models.Database.LyricsAnalyzer;
+using MuzakBot.Lib.Models.Genius;
+using MuzakBot.Lib.Models.MusicBrainz;
+using MuzakBot.Lib.Models.Odesli;
+using MuzakBot.Lib.Models.OpenAi;
+using MuzakBot.Lib.Models.QueueMessages;
+
+namespace MuzakBot.App.Modules;
+
+public partial class LyricsAnalyzerCommandModule
+{
+    /// <summary>
+    /// Handles the 'lyricsanalyzer url' slash command.
+    /// </summary>
+    /// <param name="url">The streaming service URL.</param>
+    /// <param name="promptMode">The style of the response.</param>
+    /// <param name="isPrivateResponse">Whether or not to send the response privately.</param>
+    /// <returns></returns>
+    /// <exception cref="NullReferenceException"></exception>
+    [CommandContextType(InteractionContextType.BotDm, InteractionContextType.PrivateChannel, InteractionContextType.Guild)]
+    [IntegrationType(ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall)]
+    [RequireUserRateLimit]
+    [RequireLyricsAnalyzerEnabledForServer]
+    [SlashCommand(
+        name: "url",
+        description: "Get an analysis of the lyrics of a song using a streaming service URL."
+    )]
+    private async Task LyricsAnalyzerUrlCommandAsync(
+        [Summary("url", "The URL, from a streaming service, for a song.")]
+        string url,
+        [Summary(name: "style", description: "The style of the response"),
+        Autocomplete(typeof(LyricsAnalyzerPromptStyleAutoCompleteHandler))]
+        string promptMode = "normal",
+        [Summary(name: "private", description: "Whether or not to send the response privately")]
+        bool isPrivateResponse = false
+    )
+    {
+        using var activity = _activitySource.StartLyricsAnalyzerUrlCommandAsyncActivity(url, Context);
+
+        await DeferAsync(
+            ephemeral: isPrivateResponse
+        );
+
+        using var dbContext = _lyricsAnalyzerDbContextFactory.CreateDbContext();
+
+        // Get the lyrics analyzer config from the database.
+        _logger.LogInformation("Getting lyrics analyzer config from database.");
+        LyricsAnalyzerConfig lyricsAnalyzerConfig;
+        try
+        {
+            lyricsAnalyzerConfig = await dbContext.LyricsAnalyzerConfigs
+                .WithPartitionKey("lyricsanalyzer-config")
+                .FirstAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting lyrics analyzer config from database.");
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An error occurred. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        // Get the prompt style from the database.
+        LyricsAnalyzerPromptStyle promptStyle;
+        try
+        {
+            promptStyle = await dbContext.LyricsAnalyzerPromptStyles
+                .WithPartitionKey("prompt-style")
+                .FirstAsync(item => item.ShortName == promptMode);
+        }
+        catch (NullReferenceException ex)
+        {
+            _logger.LogError(ex, "Error getting prompt style '{PromptMode}' from database.", promptMode);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("The requested prompt style does not exist. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting prompt style '{PromptMode}' from database.", promptMode);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An unknown error occurred while getting the prompt style. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        MusicEntityItem musicEntityItem;
+        try
+        {
+            musicEntityItem = await GetMusicEntityItemAsync(url);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not resolve '{url}'.", url);
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("Couldn't resolve this URL. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        PlatformEntityLink platformEntityLink;
+        try
+        {
+            platformEntityLink = GetPlatformEntityLink(musicEntityItem);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not resolve '{url}'.", url);
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("Couldn't resolve this URL. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        StreamingEntityItem streamingEntityItem = musicEntityItem.EntitiesByUniqueId![platformEntityLink.EntityUniqueId!];
+
+        if (streamingEntityItem.ItemType != "song")
+        {
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("The supplied URL is not a song. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        Song song;
+        try
+        {
+            song = await _appleMusicApiService.GetSongFromCatalogAsync(streamingEntityItem.Id!);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting song from Apple Music catalog for '{SongId}'.", streamingEntityItem.Id);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("Couldn't resolve this URL. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        string artistName = song.Attributes!.ArtistName;
+        string songName = song.Attributes!.Name;
+
+        // Get the song lyrics.
+        string lyrics;
+        try
+        {
+            lyrics = await GetSongLyricsAsync(artistName, songName, activity?.Id);
+        }
+        catch (LyricsAnalyzerDbException ex)
+        {
+            _logger.LogError(ex, "Error getting song lyrics for '{SongName}' by '{ArtistName}' from the database.", songName, artistName);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An error occurred while getting the lyrics. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+        catch (GeniusApiException ex)
+        {
+            _logger.LogError(ex, "Error getting song lyrics for '{SongName}' by '{ArtistName}' from Genius.", songName, artistName);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("Could not find lyrics for the song on Genius. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+        catch (SongRequestJobException ex)
+        {
+            _logger.LogError(ex, "Error getting song lyrics for '{SongName}' by '{ArtistName}'.", songName, artistName);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An error occurred while getting the lyrics. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unknown error occurred while getting song lyrics for '{SongName}' by '{ArtistName}'.", songName, artistName);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An unknown error occurred while getting the lyrics. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        // Analyze the lyrics with OpenAI.
+        _logger.LogInformation("Analyzing lyrics for '{SongName}' by '{ArtistName}' with OpenAI.", songName, artistName);
+        OpenAiChatCompletion openAiChatCompletion;
+        try
+        {
+            openAiChatCompletion = await _openAiService.GetLyricAnalysisAsync(
+                artistName: artistName,
+                songName: songName,
+                lyrics: lyrics,
+                promptStyle: promptStyle,
+                parentActivityId: activity?.Id
+            ) ?? throw new NullReferenceException("The response from the OpenAI API was null.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting lyric analysis for song '{songId}'.", songName);
+
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An unknown error occurred while analyzing the lyrics. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+
+        LyricsAnalyzerItem lyricsAnalyzerItem = new(
+            artistName: artistName,
+            songName: songName,
+            promptStyle: promptStyle.ShortName
+        );
+
+        dbContext.LyricsAnalyzerItems.Add(lyricsAnalyzerItem);
+
+        await dbContext.SaveChangesAsync();
+
+        // Build the response.
+        LyricsAnalyzerResponse lyricsAnalyzerResponse = new(
+            artistName: artistName,
+            songName: songName,
+            openAiChatCompletion: openAiChatCompletion,
+            promptStyle: promptStyle,
+            responseId: lyricsAnalyzerItem.Id
+        );
+
+        // Send the response to Discord.
+        _logger.LogInformation("Sending response to Discord.");
+        try
+        {
+            await FollowupAsync(
+                text: lyricsAnalyzerResponse.GenerateText(),
+                embed: lyricsAnalyzerResponse.GenerateEmbed().Build(),
+                components: lyricsAnalyzerResponse.GenerateComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            bool userIsOnRateLimitIgnoreList = lyricsAnalyzerConfig.RateLimitIgnoredUserIds is not null && lyricsAnalyzerConfig.RateLimitIgnoredUserIds.Contains(Context.User.Id.ToString());
+            LyricsAnalyzerUserRateLimit? lyricsAnalyzerUserRateLimit = await dbContext.LyricsAnalyzerUserRateLimits
+                .WithPartitionKey("user-item")
+                .FirstOrDefaultAsync(item => item.UserId == Context.User.Id.ToString());
+
+            if (lyricsAnalyzerUserRateLimit is null)
+            {
+                lyricsAnalyzerUserRateLimit = new(Context.User.Id.ToString());
+
+                dbContext.LyricsAnalyzerUserRateLimits.Add(lyricsAnalyzerUserRateLimit);
+
+                await dbContext.SaveChangesAsync();
+            }
+
+            if (lyricsAnalyzerConfig.RateLimitEnabled && !userIsOnRateLimitIgnoreList)
+            {
+                _logger.LogInformation("Updating rate limit for user '{UserId}' in database.", Context.User.Id);
+                lyricsAnalyzerUserRateLimit!.IncrementRequestCount();
+                lyricsAnalyzerUserRateLimit!.LastRequestTime = DateTimeOffset.UtcNow;
+
+                await dbContext.SaveChangesAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending response to Discord.");
+            await FollowupAsync(
+                embed: GenerateErrorEmbed("An error occurred while sending the response. 😥").Build(),
+                components: GenerateRemoveComponent().Build(),
+                ephemeral: isPrivateResponse
+            );
+
+            activity?.SetStatus(ActivityStatusCode.Error);
+
+            return;
+        }
+    }
+}

--- a/src/App/Modules/LyricsAnalyzerCommandModule/Helpers/OdesliMethods.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Helpers/OdesliMethods.cs
@@ -1,0 +1,59 @@
+using MuzakBot.Lib.Models.Odesli;
+
+namespace MuzakBot.App.Modules;
+
+public partial class LyricsAnalyzerCommandModule
+{
+    /// <summary>
+    /// Gets the share links for a song/album from a streaming service URL.
+    /// </summary>
+    /// <param name="url">The URL to a song/album on a streaming service.</param>
+    /// <returns>The music entity item.</returns>
+    private async Task<MusicEntityItem> GetMusicEntityItemAsync(string url)
+    {
+        MusicEntityItem? musicEntityItem = null;
+        try
+        {
+            musicEntityItem = await _odesliService.GetShareLinksAsync(url);
+
+            if (musicEntityItem is null)
+            {
+                throw new Exception("No share links found.");
+            }
+        }
+        catch (Exception)
+        {
+            throw;
+        }
+
+        return musicEntityItem;
+    }
+
+    /// <summary>
+    /// Gets the platform entity link for a music entity item.
+    /// </summary>
+    /// <param name="musicEntityItem">The music entity item.</param>
+    /// <returns>The platform entity link.</returns>
+    private PlatformEntityLink GetPlatformEntityLink(MusicEntityItem musicEntityItem)
+    {
+        PlatformEntityLink? platformEntityLink = null!;
+
+        try
+        {
+            platformEntityLink = musicEntityItem.LinksByPlatform!["itunes"];
+        }
+        catch (Exception)
+        {
+            try
+            {
+                platformEntityLink = musicEntityItem.LinksByPlatform!["appleMusic"];
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+        return platformEntityLink;
+    }
+}

--- a/src/App/Modules/LyricsAnalyzerCommandModule/LyricsAnalyzerCommandModule.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/LyricsAnalyzerCommandModule.cs
@@ -21,7 +21,7 @@ public partial class LyricsAnalyzerCommandModule : InteractionModuleBase<SocketI
 {
     private bool _isDisposed;
     private readonly ActivitySource _activitySource = new("MuzakBot.App.Modules.LyricsAnalyzerCommandModule");
-    private readonly IMusicBrainzService _musicBrainzService;
+    private readonly IOdesliService _odesliService;
     private readonly IAppleMusicApiService _appleMusicApiService;
     private readonly IGeniusApiService _geniusApiService;
     private readonly IOpenAiService _openAiService;
@@ -33,14 +33,14 @@ public partial class LyricsAnalyzerCommandModule : InteractionModuleBase<SocketI
     /// <summary>
     /// Initializes a new instance of the <see cref="LyricsAnalyzerCommandModule"/> class.
     /// </summary>
-    /// <param name="musicBrainzService">The <see cref="IMusicBrainzService"/>.</param>
+    /// <param name="odesliService">The <see cref="IOdesliService"/>.</param>
     /// <param name="geniusApiService">The <see cref="IGeniusApiService"/>.</param>
     /// <param name="openAiService">The <see cref="IOpenAiService"/>.</param>
     /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/>.</param>
     /// <param name="logger">The logger.</param>
-    public LyricsAnalyzerCommandModule(IMusicBrainzService musicBrainzService, IAppleMusicApiService appleMusicApiService, IGeniusApiService geniusApiService, IOpenAiService openAiService, IDbContextFactory<LyricsAnalyzerDbContext> lyricsAnalyzerContextFactory, IQueueClientService queueClientService, IHttpClientFactory httpClientFactory, ILogger<LyricsAnalyzerCommandModule> logger)
+    public LyricsAnalyzerCommandModule(IOdesliService odesliService, IAppleMusicApiService appleMusicApiService, IGeniusApiService geniusApiService, IOpenAiService openAiService, IDbContextFactory<LyricsAnalyzerDbContext> lyricsAnalyzerContextFactory, IQueueClientService queueClientService, IHttpClientFactory httpClientFactory, ILogger<LyricsAnalyzerCommandModule> logger)
     {
-        _musicBrainzService = musicBrainzService;
+        _odesliService = odesliService;
         _appleMusicApiService = appleMusicApiService;
         _geniusApiService = geniusApiService;
         _openAiService = openAiService;

--- a/src/Lib/Models/Odesli/StreamingEntityItem.cs
+++ b/src/Lib/Models/Odesli/StreamingEntityItem.cs
@@ -13,6 +13,10 @@ public class StreamingEntityItem : IStreamingEntityItem
     [JsonConverter(typeof(JsonNumberToStringConverter))]
     public string? Id { get; set; }
 
+    /// <inheritdoc cref="IStreamingEntityItem.ItemType" />
+    [JsonPropertyName("type")]
+    public string? ItemType { get; set; }
+
     /// <inheritdoc cref="IStreamingEntityItem.Title" />
     [JsonPropertyName("title")]
     public string? Title { get; set; }

--- a/src/Lib/Models/Odesli/interfaces/IStreamingEntityItem.cs
+++ b/src/Lib/Models/Odesli/interfaces/IStreamingEntityItem.cs
@@ -11,6 +11,14 @@ public interface IStreamingEntityItem
     string? Id { get; set; }
 
     /// <summary>
+    /// The type of the entity on the music streaming platform.
+    /// </summary>
+    /// <remarks>
+    /// Valid values are: "song" or "album".
+    /// </remarks>
+    string? ItemType { get; set; }
+
+    /// <summary>
     /// The name of the song/album on the music streaming platform.
     /// </summary>
     string? Title { get; set; }


### PR DESCRIPTION
## Description

This PR adds a new slash command, `/lyricsanalyzer url`, for running lyrics analyzer from a supplied streaming service URL.

### Type of change

- [x] 🌟 New feature
- [ ] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
