### PR TITLE
Fix '/create-prompt-style' not processing

### DIFF
--- a/src/App/Modules/AdminCommandModule/ModalInteractions/HandleCreatePromptStyleModalAsync.cs
+++ b/src/App/Modules/AdminCommandModule/ModalInteractions/HandleCreatePromptStyleModalAsync.cs
@@ -3,6 +3,7 @@ using Discord.Interactions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+
 using MuzakBot.Lib.Models.CommandModules;
 using MuzakBot.Lib.Models.Database.LyricsAnalyzer;
 
@@ -23,9 +24,10 @@ public partial class AdminCommandModule
 
         EmbedBuilder embed;
 
-        bool promptStyleExists = await dbContext.LyricsAnalyzerPromptStyles
+        bool promptStyleExists = dbContext.LyricsAnalyzerPromptStyles
             .WithPartitionKey("prompt-style")
-            .AnyAsync(x => x.ShortName == promptStyle.ShortName);
+            .ToList()
+            .Any(item => item.ShortName == promptStyle.ShortName);
 
         if (promptStyleExists)
         {


### PR DESCRIPTION
## Description

This PR fixes a bug with the `/create-prompt-style` command where it would fail to create the prompt style due to a client-side processing of an EF Core query.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
