### PR TITLE
Add meta tags to website pages

### DIFF
--- a/src/WebApp/Components/App.razor
+++ b/src/WebApp/Components/App.razor
@@ -4,15 +4,28 @@
 <html lang="en">
 
 <head>
+    <base href="/" />
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0, shrink-to-fit=no" name="viewport" />
-    <base href="/" />
+
+    <PageTitle>MuzakBot</PageTitle>
+    <HeadOutlet />
+    
+    <!-- Theme color attribute. Primarily for theming supported web browsers. -->
+    <meta content="#3c424f" name="theme-color" />
+
+    <!-- Twitter Posting Format -->
+    <meta content="summary" name="twitter:card" />
+    <meta content="@@thetimmysmalls" name="twitter:creator" />
+
+    <!-- OpenGraph Data -->
+    <meta content="https://muzakbot.smalls.online/images/logo_wide_social.png" property="og:image" />
+    <meta property="og:locale" content="en_US" />
 
     <link href="favicon.ico" rel="icon" type="image/ico" />
 
     <link rel="stylesheet" href="css/main.css" />
     <link href="css/bootstrap-icons/bootstrap-icons.css" rel="stylesheet" />
-    <HeadOutlet />
 </head>
 
 <body>

--- a/src/WebApp/Components/Pages/Home.razor
+++ b/src/WebApp/Components/Pages/Home.razor
@@ -4,7 +4,27 @@
 
 @page "/"
 
-<PageTitle>MuzakBot</PageTitle>
+<HeadContent>
+    <!-- Generic meta tags -->
+    <PageTitle>MuzakBot</PageTitle>
+    <meta content="A Discord bot to easily share music from one music streaming service to other streaming services." name="description" />
+    <meta content="Tim Small" name="author" />
+
+    <!-- OpenGraph/Facebook meta tags -->
+    <meta content="MuzakBot" name="title" property="og:title" />
+    <meta content="A Discord bot to easily share music from one music streaming service to other streaming services." property="og:description" />
+    <meta content="https://muzakbot.smalls.online/" property="og:url" />
+    <meta content="website" property="og:type">
+    <meta content="https://muzakbot.smalls.online/images/logo_wide_social.png" property="og:image">
+
+    <!-- Twitter meta tags -->
+    <meta content="summary_large_image" name="twitter:card">
+    <meta content="MuzakBot" name="twitter:title">
+    <meta content="A Discord bot to easily share music from one music streaming service to other streaming services." name="twitter:description">
+    <meta content="muzakbot.smalls.online" property="twitter:domain">
+    <meta content="https://muzakbot.smalls.online" property="twitter:url">
+    <meta content="https://muzakbot.smalls.online/images/logo_wide_social.png" name="twitter:image">
+</HeadContent>
 
 <PageCard Title="Home" Icon="house-fill">
     <div class="basis-full">

--- a/src/WebApp/Components/Pages/LyricsAnalyzer/ViewLyricsAnalysis.razor
+++ b/src/WebApp/Components/Pages/LyricsAnalyzer/ViewLyricsAnalysis.razor
@@ -19,7 +19,25 @@
 
     @if (_analyzedLyrics is not null && _analyzedLyricsEnriched is not null && !_errorOccurred && !_loading)
     {
+        <!-- Generic meta tags -->
         <PageTitle>MuzakBot - Lyrics analysis - @_analyzedLyrics.SongName by @_analyzedLyrics.ArtistName</PageTitle>
+        <meta content="AI generated lyrics analysis for the song '@(_analyzedLyrics.SongName)' by @(_analyzedLyrics.ArtistName)." name="description" />
+        <meta content="Tim Small" name="author" />
+
+        <!-- OpenGraph/Facebook meta tags -->
+        <meta content="MuzakBot" name="title" property="og:title" />
+        <meta content="AI generated lyrics analysis for the song '@(_analyzedLyrics.SongName)' by @(_analyzedLyrics.ArtistName)." property="og:description" />
+        <meta content="https://muzakbot.smalls.online/lyrics-analyzer/analysis/@(AnalysisId!)" property="og:url" />
+        <meta content="website" property="og:type">
+        <meta content="https://muzakbot.smalls.online/images/logo_wide_social.png" property="og:image">
+
+        <!-- Twitter meta tags -->
+        <meta content="summary_large_image" name="twitter:card">
+        <meta content="MuzakBot" name="twitter:title">
+        <meta content="AI generated lyrics analysis for the song '@(_analyzedLyrics.SongName)' by @(_analyzedLyrics.ArtistName)." name="twitter:description">
+        <meta content="muzakbot.smalls.online" property="twitter:domain">
+        <meta content="https://muzakbot.smalls.online/lyrics-analyzer/analysis/@(AnalysisId!)" property="twitter:url">
+        <meta content="https://muzakbot.smalls.online/images/logo_wide_social.png" name="twitter:image">
     }
 </HeadContent>
 


### PR DESCRIPTION
## Description

This PR adds meta tags for the website's pages, which should enrich sharing the URLs on other platforms (Facebook, ~~X~~ Twitter, Mastodon, etc).

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
