### PR TITLE
Fix title meta tag for lyrics analysis page on website

### DIFF
--- a/src/WebApp/Components/Pages/LyricsAnalyzer/ViewLyricsAnalysis.razor
+++ b/src/WebApp/Components/Pages/LyricsAnalyzer/ViewLyricsAnalysis.razor
@@ -25,7 +25,7 @@
         <meta content="Tim Small" name="author" />
 
         <!-- OpenGraph/Facebook meta tags -->
-        <meta content="MuzakBot" name="title" property="og:title" />
+        <meta content="MuzakBot - Lyrics analysis - @_analyzedLyrics.SongName by @_analyzedLyrics.ArtistName" name="title" property="og:title" />
         <meta content="AI generated lyrics analysis for the song '@(_analyzedLyrics.SongName)' by @(_analyzedLyrics.ArtistName)." property="og:description" />
         <meta content="https://muzakbot.smalls.online/lyrics-analyzer/analysis/@(AnalysisId!)" property="og:url" />
         <meta content="website" property="og:type">
@@ -33,7 +33,7 @@
 
         <!-- Twitter meta tags -->
         <meta content="summary_large_image" name="twitter:card">
-        <meta content="MuzakBot" name="twitter:title">
+        <meta content="MuzakBot - Lyrics analysis - @_analyzedLyrics.SongName by @_analyzedLyrics.ArtistName" name="twitter:title">
         <meta content="AI generated lyrics analysis for the song '@(_analyzedLyrics.SongName)' by @(_analyzedLyrics.ArtistName)." name="twitter:description">
         <meta content="muzakbot.smalls.online" property="twitter:domain">
         <meta content="https://muzakbot.smalls.online/lyrics-analyzer/analysis/@(AnalysisId!)" property="twitter:url">


### PR DESCRIPTION
## Description

This PR fixes the title meta tag on the lyrics analysis page being just "MuzakBot" and not "MuzakBot - Lyrics analysis - Song Name by Artist Name".

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
