### PR TITLE
Remove private assets value for BlazorMD.SourceGenerator

### DIFF
--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
     <!-- Dependencies -->
     <ItemGroup>
-        <PackageReference Include="BlazorMD.SourceGenerator" PrivateAssets="all" />
+        <PackageReference Include="BlazorMD.SourceGenerator" />
         <PackageReference Include="Discord.Net" />
         <PackageReference Include="MarkDig" />
     </ItemGroup>


### PR DESCRIPTION
## Description

* Removes the `PrivateAssets="all"` value for the `BlazorMD.SourceGenerator` package.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
