### PR TITLE
Update logo sizing on homepage

### DIFF
--- a/src/WebApp/CSS/main.dev.css
+++ b/src/WebApp/CSS/main.dev.css
@@ -284,19 +284,11 @@ body {
     }
 }
 
-@media (max-width: 991px) {
-    .muzakbot-logo-img {
-        height: auto;
-        width: 100%;
-    }
-}
-
-@media (min-width: 992px) {
-    .muzakbot-logo-img {
-        height: auto;
-        width: 256px;
-        max-width: 256px;
-    }
+.muzakbot-logo-img {
+    @apply h-auto mx-auto;
+    @apply w-4/5;
+    @apply sm:w-5/12;
+    @apply lg:w-64;
 }
 
 .notice-info {


### PR DESCRIPTION
## Description

* Make the logo not take up the whole screen on smaller width screens.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
