### PR TITLE
Rename IResponse to IBotResponse

### DIFF
--- a/src/App/Models/Responses/AlbumReleaseLookupResponse.cs
+++ b/src/App/Models/Responses/AlbumReleaseLookupResponse.cs
@@ -10,7 +10,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Represents a response for the album release lookup command.
 /// </summary>
-public sealed class AlbumReleaseLookupResponse : IResponse, IDisposable
+public sealed class AlbumReleaseLookupResponse : IBotResponse, IDisposable
 {
     private bool _isDisposed;
 

--- a/src/App/Models/Responses/AlbumReleaseReminderAddedResponse.cs
+++ b/src/App/Models/Responses/AlbumReleaseReminderAddedResponse.cs
@@ -7,7 +7,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Represents a response for when an album release reminder is added for a user. 
 /// </summary>
-public sealed class AlbumReleaseReminderAddedResponse : IResponse
+public sealed class AlbumReleaseReminderAddedResponse : IBotResponse
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AlbumReleaseReminderAddedResponse"/> class.

--- a/src/App/Models/Responses/AlbumReleaseReminderResponse.cs
+++ b/src/App/Models/Responses/AlbumReleaseReminderResponse.cs
@@ -11,7 +11,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Represents a response for the album release reminder.
 /// </summary>
-public sealed class AlbumReleaseReminderResponse : IResponse, IDisposable
+public sealed class AlbumReleaseReminderResponse : IBotResponse, IDisposable
 {
     private bool _isDisposed;
 

--- a/src/App/Models/Responses/BotInfoResponse.cs
+++ b/src/App/Models/Responses/BotInfoResponse.cs
@@ -7,7 +7,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Represents a response containing information about the bot.
 /// </summary>
-public sealed class BotInfoResponse : IResponse
+public sealed class BotInfoResponse : IBotResponse
 {
     private readonly string _currentYear = DateTimeOffset.Now.ToString("yyyy");
     private readonly Version? _assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version;

--- a/src/App/Models/Responses/IBotResponse.cs
+++ b/src/App/Models/Responses/IBotResponse.cs
@@ -5,7 +5,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Interface for a response to a bot interaction.
 /// </summary>
-public interface IResponse
+public interface IBotResponse
 {
     /// <summary>
     /// Generates the text for the response.

--- a/src/App/Models/Responses/LyricsAnalyzerResponse.cs
+++ b/src/App/Models/Responses/LyricsAnalyzerResponse.cs
@@ -10,7 +10,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Represents a response for the lyrics analyzer command.
 /// </summary>
-public class LyricsAnalyzerResponse : IResponse
+public class LyricsAnalyzerResponse : IBotResponse
 {
     /// <summary>
     /// Initialize a new instance of the <see cref="LyricsAnalyzerResponse"/> class.

--- a/src/App/Models/Responses/ShareMusicResponse.cs
+++ b/src/App/Models/Responses/ShareMusicResponse.cs
@@ -9,7 +9,7 @@ namespace MuzakBot.App.Models.Responses;
 /// <summary>
 /// Represents a response for the share music command.
 /// </summary>
-public class ShareMusicResponse : IResponse
+public class ShareMusicResponse : IBotResponse
 {
     private readonly PlatformEntityLink? _youtubeLink;
     private readonly PlatformEntityLink? _appleMusicLink;


### PR DESCRIPTION
## Description

* Rename the interface for `IResponse` to `IBotResponse` to better match what it's used for.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
