### PR TITLE
Add telemetry and logging to the album release services

### DIFF
--- a/src/App/Extensions/OpenTelemetryExtensions.cs
+++ b/src/App/Extensions/OpenTelemetryExtensions.cs
@@ -155,6 +155,7 @@ internal static class OpenTelemetryExtensions
         return builder
             .AddSource("MuzakBot.App.Modules.ShareMusicCommandModule")
             .AddSource("MuzakBot.App.Modules.LyricsAnalyzerCommandModule")
+            .AddSource("MuzakBot.App.Modules.AlbumReleaseLookupCommandModule")
             .AddSource("MuzakBot.App.Services.DiscordService");
     }
 }

--- a/src/App/Extensions/OpenTelemetryExtensions.cs
+++ b/src/App/Extensions/OpenTelemetryExtensions.cs
@@ -156,6 +156,7 @@ internal static class OpenTelemetryExtensions
             .AddSource("MuzakBot.App.Modules.ShareMusicCommandModule")
             .AddSource("MuzakBot.App.Modules.LyricsAnalyzerCommandModule")
             .AddSource("MuzakBot.App.Modules.AlbumReleaseLookupCommandModule")
+            .AddSource("MuzakBot.App.Services.AlbumReleaseReminderMonitorService")
             .AddSource("MuzakBot.App.Services.DiscordService");
     }
 }

--- a/src/App/Modules/AlbumReleaseCommandModule/Commands/AlbumReleaseLookupSlashCommandAsync.cs
+++ b/src/App/Modules/AlbumReleaseCommandModule/Commands/AlbumReleaseLookupSlashCommandAsync.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 using Discord;
@@ -37,6 +38,18 @@ public partial class AlbumReleaseCommandModule
         string albumId
     )
     {
+        using var activity = _activitySource.StartActivity(
+            name: "AlbumReleaseLookupSlashCommandAsync",
+            kind: ActivityKind.Server,
+            tags: new ActivityTagsCollection
+            {
+                { "command_Type", "SlashCommand" },
+                { "command_Name", "albumrelease lookup" },
+                { "artist_Id", artistId },
+                { "album_Id", albumId }
+            }
+        );
+
         await DeferAsync();
 
         Album album;
@@ -53,6 +66,8 @@ public partial class AlbumReleaseCommandModule
                 components: GenerateRemoveComponent().Build()
             );
 
+            activity?.SetStatus(ActivityStatusCode.Error);
+
             return;
         }
 
@@ -62,6 +77,7 @@ public partial class AlbumReleaseCommandModule
                 embed: GenerateErrorEmbed("This album has already been released.").Build(),
                 components: GenerateRemoveComponent().Build()
             );
+
             return;
         }
 
@@ -80,6 +96,8 @@ public partial class AlbumReleaseCommandModule
                 components: GenerateRemoveComponent().Build()
             );
 
+            activity?.SetStatus(ActivityStatusCode.Error);
+
             return;
         }
 
@@ -91,5 +109,7 @@ public partial class AlbumReleaseCommandModule
             fileName: albumReleaseLookupResponse.AlbumArtFileName,
             fileStream: albumReleaseLookupResponse.AlbumArtworkStream
         );
+
+        _logger.LogInformation("Album release lookup response sent for album {AlbumId}", album.Id);
     }
 }

--- a/src/App/Modules/AlbumReleaseCommandModule/ComponentInteractions/HandleRemindMeButtonClickAsync.cs
+++ b/src/App/Modules/AlbumReleaseCommandModule/ComponentInteractions/HandleRemindMeButtonClickAsync.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using Discord;
 using Discord.Interactions;
 using Discord.Rest;
@@ -28,6 +30,18 @@ public partial class AlbumReleaseCommandModule
         var componentInteraction = (Context.Interaction as IComponentInteraction)!;
 
         await componentInteraction.DeferLoadingAsync(true);
+
+        using var activity = _activitySource.StartActivity(
+            name: "HandleRemindMeButtonClickAsync",
+            kind: ActivityKind.Server,
+            tags: new ActivityTagsCollection
+            {
+                { "command_Type", "ComponentInteraction" },
+                { "command_Name", "Remind me" },
+                { "user_Id", componentInteraction.User.Id.ToString() },
+                { "album_Id", albumId }
+            }
+        );
 
         Album album = await _appleMusicApiService.GetAlbumFromCatalogAsync(albumId);
 
@@ -99,5 +113,7 @@ public partial class AlbumReleaseCommandModule
             embed: reminderAddedResponse.GenerateEmbed().Build(),
             ephemeral: true
         );
+
+        _logger.LogInformation("User {UserId} has been added to be reminded for album {AlbumId}", Context.User.Id, album.Id);
     }
 }


### PR DESCRIPTION
## Description

* Adds telemetry and logging to `AlbumReleaseCommandModule`.
* Adds telemetry and logging to `AlbumReleaseReminderMonitorService`.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
