### PR TITLE
Update exception handling when sending album release reminders

### DIFF
--- a/src/App/Exceptions/AlbumReleases/AlbumReleaseReminderException.cs
+++ b/src/App/Exceptions/AlbumReleases/AlbumReleaseReminderException.cs
@@ -1,0 +1,33 @@
+namespace MuzakBot.App;
+
+/// <summary>
+/// An exception that occurred while processing an album release reminder.
+/// </summary>
+public class AlbumReleaseReminderException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlbumReleaseReminderException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="exceptionType">The type of exception that occurred.</param>
+    public AlbumReleaseReminderException(string message, AlbumReleaseReminderExceptionType exceptionType) : base(message)
+    {
+        ExceptionType = exceptionType;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlbumReleaseReminderException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="exceptionType">The type of exception that occurred.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public AlbumReleaseReminderException(string message, AlbumReleaseReminderExceptionType exceptionType, Exception innerException) : base(message, innerException)
+    {
+        ExceptionType = exceptionType;
+    }
+
+    /// <summary>
+    /// The type of exception that occurred.
+    /// </summary>
+    public AlbumReleaseReminderExceptionType ExceptionType { get; set; }
+}

--- a/src/App/Exceptions/AlbumReleases/AlbumReleaseReminderExceptionType.cs
+++ b/src/App/Exceptions/AlbumReleases/AlbumReleaseReminderExceptionType.cs
@@ -1,0 +1,27 @@
+namespace MuzakBot.App;
+
+/// <summary>
+/// The type of exception that occurred while processing an album release reminder.
+/// </summary>
+public enum AlbumReleaseReminderExceptionType
+{
+    /// <summary>
+    /// An unknown exception occurred.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The Odesli service returned null.
+    /// </summary>
+    OdesliServiceReturnedNull = 1,
+
+    /// <summary>
+    /// The channel specified in the album release reminder does not exist.
+    /// </summary>
+    ChannelDoesNotExist = 2,
+
+    /// <summary>
+    /// The album release reminder failed to send.
+    /// </summary>
+    FailedToSendMessage = 3
+}

--- a/src/App/Services/AlbumReleaseReminderMonitorService/AlbumReleaseReminderMonitorService.cs
+++ b/src/App/Services/AlbumReleaseReminderMonitorService/AlbumReleaseReminderMonitorService.cs
@@ -181,8 +181,10 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
             usersToNotify.Add($"<@{userItem}>");
         }
 
+        // Get the album from the Apple Music catalog.
         Album album = await _appleMusicApiService.GetAlbumFromCatalogAsync(releaseReminder.AlbumId);
 
+        // Get the share links for the album.
         MusicEntityItem? musicEntityItem = await _odesliService.GetShareLinksAsync(album.Attributes!.Url);
 
         if (musicEntityItem is null)
@@ -192,8 +194,10 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
             throw new AlbumReleaseReminderException("The Odesli service returned null for the album.", AlbumReleaseReminderExceptionType.OdesliServiceReturnedNull);
         }
 
+        // Create the album release reminder response.
         using AlbumReleaseReminderResponse albumReleaseReminderResponse = new(album, musicEntityItem, usersToNotify);
 
+        // Get the channel to send the album release reminder to.
         SocketTextChannel channel = guildItem.GetTextChannel(ulong.Parse(releaseReminder.ChannelId));
 
         if (channel is null)
@@ -209,6 +213,7 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
 
         try
         {
+            // Send the album release reminder.
             using FileAttachment fileAttachment = new(albumReleaseReminderResponse.AlbumArtworkStream, albumReleaseReminderResponse.AlbumArtFileName);
 
             await channel.SendFileAsync(

--- a/src/App/Services/AlbumReleaseReminderMonitorService/AlbumReleaseReminderMonitorService.cs
+++ b/src/App/Services/AlbumReleaseReminderMonitorService/AlbumReleaseReminderMonitorService.cs
@@ -89,7 +89,54 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
                     {
                         if (releaseReminder.ReleaseDate <= currentTime)
                         {
-                            await SendAlbumReleaseReminderAsync(releaseReminder, guildItem);
+                            try
+                            {
+                                await SendAlbumReleaseReminderAsync(releaseReminder, guildItem);
+                            }
+                            catch (AlbumReleaseReminderException ex) when (ex.ExceptionType == AlbumReleaseReminderExceptionType.OdesliServiceReturnedNull)
+                            {
+                                _logger.LogError(
+                                    exception: ex,
+                                    message: "Could not retrieve share links for the album '{AlbumId}' when sending album release reminder to guild '{GuildId}'.",
+                                    releaseReminder.AlbumId,
+                                    guildItem.Id
+                                );
+
+                                continue;
+                            }
+                            catch (AlbumReleaseReminderException ex) when (ex.ExceptionType == AlbumReleaseReminderExceptionType.ChannelDoesNotExist)
+                            {
+                                _logger.LogError(
+                                    exception: ex,
+                                    message: "The channel '{ChannelId}' specified in the album release reminder does not exist when sending album release reminder to guild '{GuildId}'.",
+                                    releaseReminder.ChannelId,
+                                    guildItem.Id
+                                );
+
+                                continue;
+                            }
+                            catch (AlbumReleaseReminderException ex) when (ex.ExceptionType == AlbumReleaseReminderExceptionType.FailedToSendMessage)
+                            {
+                                _logger.LogError(
+                                    exception: ex,
+                                    message: "Failed to send album release reminder for album '{AlbumId}' to guild '{GuildId}'.",
+                                    releaseReminder.AlbumId,
+                                    guildItem.Id
+                                );
+
+                                continue;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(
+                                    exception: ex,
+                                    message: "An unknown exception occurred when sending album release reminder for album '{AlbumId}' to guild '{GuildId}'.",
+                                    releaseReminder.AlbumId,
+                                    guildItem.Id
+                                );
+
+                                continue;
+                            }
                         }
                     }
 
@@ -113,8 +160,7 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
     /// <param name="releaseReminder">The album release reminder.</param>
     /// <param name="guildItem">The guild.</param>
     /// <returns></returns>
-    /// <exception cref="NullReferenceException">Thrown when share links from Odesli or the channel are null.</exception>
-    /// <exception cref="Exception">Thrown when the album release reminder fails to send.</exception>
+    /// <exception cref="AlbumReleaseReminderException">Thrown when an exception occurs while sending the album release reminder.</exception>
     private async Task SendAlbumReleaseReminderAsync(AlbumReleaseReminder releaseReminder, SocketGuild guildItem)
     {
         using var activity = _activitySource.StartActivity(
@@ -141,11 +187,9 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
 
         if (musicEntityItem is null)
         {
-            _logger.LogWarning("Failed to get share links for album {AlbumId}. Skipping for now.", releaseReminder.AlbumId);
-
             activity?.SetStatus(ActivityStatusCode.Error);
 
-            throw new NullReferenceException("Failed to get share links for album.");
+            throw new AlbumReleaseReminderException("The Odesli service returned null for the album.", AlbumReleaseReminderExceptionType.OdesliServiceReturnedNull);
         }
 
         using AlbumReleaseReminderResponse albumReleaseReminderResponse = new(album, musicEntityItem, usersToNotify);
@@ -157,16 +201,16 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
             activity?.SetStatus(ActivityStatusCode.Error);
 
             releaseReminder.ReminderSent = true;
-            
-            throw new NullReferenceException("Failed to get channel.");
+
+            throw new AlbumReleaseReminderException("The channel specified in the album release reminder does not exist.", AlbumReleaseReminderExceptionType.ChannelDoesNotExist);
         }
 
         _logger.LogInformation("Sending album release reminder for album {AlbumId} to guild {GuildId}.", releaseReminder.AlbumId, guildItem.Id);
 
-        FileAttachment fileAttachment = new(albumReleaseReminderResponse.AlbumArtworkStream, albumReleaseReminderResponse.AlbumArtFileName);
-
         try
         {
+            using FileAttachment fileAttachment = new(albumReleaseReminderResponse.AlbumArtworkStream, albumReleaseReminderResponse.AlbumArtFileName);
+
             await channel.SendFileAsync(
                 embed: albumReleaseReminderResponse.GenerateEmbed().Build(),
                 components: albumReleaseReminderResponse.GenerateComponent().Build(),
@@ -178,11 +222,9 @@ public sealed class AlbumReleaseReminderMonitorService : IAlbumReleaseReminderMo
         {
             activity?.SetStatus(ActivityStatusCode.Error);
 
-            _logger.LogError(ex, "Failed to send album release reminder for album {AlbumId} to guild {GuildId}.", releaseReminder.AlbumId, guildItem.Id);
-
             albumReleaseReminderResponse.Dispose();
 
-            throw new Exception("Failed to send album release reminder.", ex);
+            throw new AlbumReleaseReminderException("The album release reminder failed to send.", AlbumReleaseReminderExceptionType.FailedToSendMessage, ex);
         }
 
         releaseReminder.ReminderSent = true;


### PR DESCRIPTION
## Description

* Adds a custom exception for album release reminders.
* Improves exception handling when it's processing album release reminders to send.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
