### PR TITLE
Fix Apple Music API service token refresh

### DIFF
--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -81,6 +81,10 @@ builder.Services
         options.AppleAppId = builder.Configuration.GetValue<string>("APPLE_APP_ID") ?? throw new("APPLE_APP_ID is not set.");
         options.AppleAppKeyId = builder.Configuration.GetValue<string>("APPLE_APP_KEY_ID") ?? throw new("APPLE_APP_KEY_ID is not set");
         options.AppleAppKey = builder.Configuration.GetValue<string>("APPLE_APP_KEY") ?? throw new("APPLE_APP_KEY is not set.");
+
+        options.TokenExpiration = builder.Configuration.GetValue<string>("APPLE_TOKEN_EXPIRATION_MINUTES") is not null
+            ? TimeSpan.FromMinutes(builder.Configuration.GetValue<int>("APPLE_TOKEN_EXPIRATION_MINUTES"))
+            : TimeSpan.FromMinutes(30);
     });
 
 DatabaseConfig databaseConfig = builder.Configuration.GetDatabaseConfig();

--- a/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiService.cs
+++ b/src/Lib.Services/Services/AppleMusicApiService/AppleMusicApiService.cs
@@ -289,7 +289,7 @@ public partial class AppleMusicApiService : IAppleMusicApiService
 
         if (_bearerToken is null || string.IsNullOrWhiteSpace(_bearerToken) || IsTokenExpired())
         {
-            GenerateBearerToken();
+            GenerateBearerToken(true);
         }
 
         _logger.LogInformation("Sending request to: {url}", request.CreateUrlPath());
@@ -313,9 +313,15 @@ public partial class AppleMusicApiService : IAppleMusicApiService
     /// <summary>
     /// Generate a bearer token for the Apple Music API.
     /// </summary>
-    private void GenerateBearerToken()
+    private void GenerateBearerToken() => GenerateBearerToken(false);
+
+    /// <summary>
+    /// Generate a bearer token for the Apple Music API.
+    /// </summary>
+    /// <param name="force">Force the generation of a new token.</param>
+    private void GenerateBearerToken(bool force)
     {
-        if (!IsTokenExpired())
+        if (!force && !IsTokenExpired())
         {
             return;
         }


### PR DESCRIPTION
## Description

* This fixes a bug with `AppleMusicApiService` and how it handles token refreshing. It was easily noticeable when using `/sharemusic url` and `/lyricsanalyzer url`.

<img width="294" alt="image" src="https://github.com/Smalls1652/MuzakBot/assets/1042907/28d045ad-21c7-40f4-8250-6693f3b9bd14">

* The main change revolves around initializing the private app key, for signing the JWT, at the start of the service and disposing it when the service itself is disposed.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
