### PR TITLE
Try to make Genius lookups more accurate

### DIFF
--- a/src/App/Modules/LyricsAnalyzerCommandModule/Commands/LyricsAnalyzerSearchCommandAsync.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Commands/LyricsAnalyzerSearchCommandAsync.cs
@@ -173,7 +173,7 @@ public partial class LyricsAnalyzerCommandModule
         string lyrics;
         try
         {
-            lyrics = await GetSongLyricsAsync(artistName, songName, activity?.Id);
+            lyrics = await GetSongLyricsAsync(artistName, songName, song.Id, activity?.Id);
         }
         catch (LyricsAnalyzerDbException ex)
         {

--- a/src/App/Modules/LyricsAnalyzerCommandModule/Commands/LyricsAnalyzerUrlCommandAsync.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Commands/LyricsAnalyzerUrlCommandAsync.cs
@@ -200,7 +200,7 @@ public partial class LyricsAnalyzerCommandModule
         string lyrics;
         try
         {
-            lyrics = await GetSongLyricsAsync(artistName, songName, activity?.Id);
+            lyrics = await GetSongLyricsAsync(artistName, songName, song.Id, activity?.Id);
         }
         catch (LyricsAnalyzerDbException ex)
         {

--- a/src/App/Modules/LyricsAnalyzerCommandModule/ComponentInteractions/HandleLyricsAnalyzerRegenerateAsync.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/ComponentInteractions/HandleLyricsAnalyzerRegenerateAsync.cs
@@ -140,7 +140,7 @@ public partial class LyricsAnalyzerCommandModule
         string lyrics;
         try
         {
-            lyrics = await GetSongLyricsAsync(lyricsAnalyzerItem.ArtistName, lyricsAnalyzerItem.SongName, activity?.Id);
+            lyrics = await GetSongLyricsAsync(lyricsAnalyzerItem.ArtistName, lyricsAnalyzerItem.SongName, String.Empty, activity?.Id);
         }
         catch (LyricsAnalyzerDbException ex)
         {

--- a/src/App/Modules/LyricsAnalyzerCommandModule/Helpers/SongLyricsMethods.cs
+++ b/src/App/Modules/LyricsAnalyzerCommandModule/Helpers/SongLyricsMethods.cs
@@ -91,7 +91,7 @@ public partial class LyricsAnalyzerCommandModule
 
         foreach (var searchHit in songResultItems)
         {
-            GeniusApiResponse<GeniusSongResult>? songLookup = await _geniusApiService.GetSongAsync(searchHit.Result!.Id);
+            GeniusApiResponse<GeniusSongResult>? songLookup = await _geniusApiService.GetSongAsync(searchHit.Result!.Id, parentActivityId);
 
             if (songLookup is not null && songLookup.Response is not null && songLookup.Response.Song is not null)
             {

--- a/src/Lib.Services/Extensions/Telemetry/GeniusApiServiceActivityExtensions.cs
+++ b/src/Lib.Services/Extensions/Telemetry/GeniusApiServiceActivityExtensions.cs
@@ -39,6 +39,34 @@ internal static class GeniusApiServiceActivityExtensions
     }
 
     /// <summary>
+    /// Starts an activity for <see cref="GeniusApiService.GetSongAsync(int)"/>.
+    /// </summary>
+    /// <param name="activitySource">The activity source.</param>
+    /// <param name="songId">The ID of the song.</param>
+    /// <returns>The started activity.</returns>
+    public static Activity? StartGeniusGetSongAsyncActivity(this ActivitySource activitySource, int songId) => StartGeniusGetSongAsyncActivity(activitySource, songId, null);
+
+    /// <summary>
+    /// Starts an activity for <see cref="GeniusApiService.GetSongAsync(int)"/>.
+    /// </summary>
+    /// <param name="activitySource">The activity source.</param>
+    /// <param name="songId">The ID of the song.</param>
+    /// <param name="parentActivityId">The ID of the parent activity (optional).</param>
+    /// <returns>The started activity.</returns>
+    public static Activity? StartGeniusGetSongAsyncActivity(this ActivitySource activitySource, int songId, string? parentActivityId)
+    {
+        return activitySource.StartActivity(
+            name: "GeniusGetSongAsync",
+            kind: ActivityKind.Internal,
+            tags: new ActivityTagsCollection
+            {
+                { "songId", songId }
+            },
+            parentId: parentActivityId
+        );
+    }
+
+    /// <summary>
     /// Starts an activity for <see cref="GeniusApiService.GetLyricsAsync(string)"/>.
     /// </summary>
     /// <param name="activitySource">The activity source.</param>

--- a/src/Lib.Services/JsonSourceGen/GeniusJsonContext.cs
+++ b/src/Lib.Services/JsonSourceGen/GeniusJsonContext.cs
@@ -16,5 +16,8 @@ namespace MuzakBot.Lib.Services;
 [JsonSerializable(typeof(GeniusSearchResultItem[]))]
 [JsonSerializable(typeof(GeniusSearchResultHitItem))]
 [JsonSerializable(typeof(GeniusApiResponse<GeniusSearchResult>))]
+[JsonSerializable(typeof(GeniusSongItem))]
+[JsonSerializable(typeof(GeniusSongResult))]
+[JsonSerializable(typeof(GeniusApiResponse<GeniusSongResult>))]
 internal partial class GeniusJsonContext : JsonSerializerContext
 { }

--- a/src/Lib.Services/JsonSourceGen/GeniusJsonContext.cs
+++ b/src/Lib.Services/JsonSourceGen/GeniusJsonContext.cs
@@ -11,6 +11,7 @@ namespace MuzakBot.Lib.Services;
     GenerationMode = JsonSourceGenerationMode.Default,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
 )]
+[JsonSerializable(typeof(GeniusArtist))]
 [JsonSerializable(typeof(GeniusSearchResult))]
 [JsonSerializable(typeof(GeniusSearchResultItem))]
 [JsonSerializable(typeof(GeniusSearchResultItem[]))]

--- a/src/Lib.Services/Services/GeniusApiService/interfaces/IGeniusApiService.cs
+++ b/src/Lib.Services/Services/GeniusApiService/interfaces/IGeniusApiService.cs
@@ -10,6 +10,9 @@ public interface IGeniusApiService : IDisposable
     Task<GeniusApiResponse<GeniusSearchResult>?> SearchAsync(string artistName, string songName);
     Task<GeniusApiResponse<GeniusSearchResult>?> SearchAsync(string artistName, string songName, string? parentActvitityId);
 
+    Task<GeniusApiResponse<GeniusSongResult>?> GetSongAsync(int id);
+    Task<GeniusApiResponse<GeniusSongResult>?> GetSongAsync(int id, string? parentActvitityId);
+
     Task<string> GetLyricsAsync(string url);
     Task<string> GetLyricsAsync(string url, string? parentActvitityId);
 

--- a/src/Lib/Models/Genius/GeniusArtist.cs
+++ b/src/Lib/Models/Genius/GeniusArtist.cs
@@ -1,0 +1,13 @@
+namespace MuzakBot.Lib.Models.Genius;
+
+/// <summary>
+/// Represents the primary artist of a song on Genius.
+/// </summary>
+public class GeniusArtist
+{
+    /// <summary>
+    /// The name of the primary artist.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+}

--- a/src/Lib/Models/Genius/GeniusSearchResultItem.cs
+++ b/src/Lib/Models/Genius/GeniusSearchResultItem.cs
@@ -52,4 +52,10 @@ public class GeniusSearchResultItem : IGeniusSearchResultItem
     /// </summary>
     [JsonPropertyName("lyrics_state")]
     public string? LyricsState { get; set; }
+
+    /// <summary>
+    /// The primary artist of the item.
+    /// </summary>
+    [JsonPropertyName("primary_artist")]
+    public GeniusArtist PrimaryArtist { get; set; } = null!;
 }

--- a/src/Lib/Models/Genius/GeniusSongItem.cs
+++ b/src/Lib/Models/Genius/GeniusSongItem.cs
@@ -1,0 +1,31 @@
+namespace MuzakBot.Lib.Models.Genius;
+
+/// <summary>
+/// Represents a song item from the Genius API.
+/// </summary>
+public class GeniusSongItem
+{
+    /// <summary>
+    /// The ID of the song.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The title of the song.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = null!;
+
+    /// <summary>
+    /// The URL of the song.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = null!;
+
+    /// <summary>
+    /// The ID of the song on Apple Music.
+    /// </summary>
+    [JsonPropertyName("apple_music_id")]
+    public string? AppleMusicId { get; set; }
+}

--- a/src/Lib/Models/Genius/GeniusSongResult.cs
+++ b/src/Lib/Models/Genius/GeniusSongResult.cs
@@ -1,0 +1,13 @@
+namespace MuzakBot.Lib.Models.Genius;
+
+/// <summary>
+/// Represents a song result from the Genius API.
+/// </summary>
+public class GeniusSongResult
+{
+    /// <summary>
+    /// Data for the song.
+    /// </summary>
+    [JsonPropertyName("song")]
+    public GeniusSongItem Song { get; set; } = null!;
+}


### PR DESCRIPTION
## Description

* When looking up lyrics on Genius, it will try to resolve the Genius search results to the Apple Music ID of the song.
* If it can't resolve by the Apple Music ID, it'll fall back to string comparisons like before; however, I've implemented some regex to help clean up song names and get a more "accurate" result.

It's not going to be 100% accurate still.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
