### PR TITLE
Update when explicit runtime IDs are used

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project>
   <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
   <PropertyGroup>
-    <RuntimeIdentifiers>linux-x64;linux-arm64;osx-x64;osx-arm64;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(CONTAINER_IMAGE_BUILD)'=='true'">linux-x64;linux-arm64</RuntimeIdentifiers>
 
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
 
-    <ArtifactsPivots Condition="'$(CONTAINER_IMAGE_BUILD)'=='true'">$(Configuration.ToLower())</ArtifactsPivots>
+    <ArtifactsPivots>$(Configuration.ToLower())</ArtifactsPivots>
 
   </PropertyGroup>
 </Project>

--- a/Dockerfile.GeniusService
+++ b/Dockerfile.GeniusService
@@ -5,6 +5,8 @@ ARG NUGET_TOKEN
 
 WORKDIR /app
 
+ENV CONTAINER_IMAGE_BUILD=true
+
 COPY ./global.json ./
 COPY ./MuzakBot.sln ./
 COPY ./Directory.Build.props ./

--- a/Dockerfile.MuzakBot
+++ b/Dockerfile.MuzakBot
@@ -5,6 +5,8 @@ ARG NUGET_TOKEN
 
 WORKDIR /app
 
+ENV CONTAINER_IMAGE_BUILD=true
+
 COPY ./global.json ./
 COPY ./MuzakBot.sln ./
 COPY ./Directory.Build.props ./

--- a/Dockerfile.WebApp
+++ b/Dockerfile.WebApp
@@ -5,6 +5,8 @@ ARG NUGET_TOKEN
 
 WORKDIR /app
 
+ENV CONTAINER_IMAGE_BUILD=true
+
 COPY ./global.json ./
 COPY ./MuzakBot.sln ./
 COPY ./Directory.Build.props ./


### PR DESCRIPTION
## Description

- Should only use 'linux-x64' and 'linux-arm64' during container image builds.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#298 :point\_left:
